### PR TITLE
made changes in code according to changes in HDFC Website UI

### DIFF
--- a/bank_integration/bank_integration/api/bank_api.py
+++ b/bank_integration/bank_integration/api/bank_api.py
@@ -69,7 +69,7 @@ class BankAPI:
             "Chrome/121.0.0.0 Safari/537.36"
         )
 
-        if not frappe.conf.developer_mode:
+        if frappe.conf.developer_mode:
             options.add_argument("--headless=new")
             options.add_argument("--no-sandbox")
             options.add_argument("--disable-dev-shm-usage")

--- a/bank_integration/bank_integration/api/bank_api.py
+++ b/bank_integration/bank_integration/api/bank_api.py
@@ -55,7 +55,7 @@ class BankAPI:
 
     def setup_browser(self):
         from selenium.webdriver.remote.remote_connection import RemoteConnection
-        if not isinstance(RemoteConnection._timeout, (int, float)) and RemoteConnection._timeout is not None:
+        if not isinstance(RemoteConnection._timeout, (int, float)) :
             RemoteConnection.set_timeout(90)
         self.br = webdriver.Chrome(options=self.get_options())
 

--- a/bank_integration/bank_integration/api/bank_api.py
+++ b/bank_integration/bank_integration/api/bank_api.py
@@ -37,6 +37,7 @@ class BankAPI:
         self.uid = uid or frappe.utils.random_string(7)
         self.cache_key = "bank_" + self.uid
         self.data = data
+        
 
         if getattr(self, "init"):
             self.init()
@@ -53,14 +54,34 @@ class BankAPI:
         pass
 
     def setup_browser(self):
-        self.br = webdriver.Chrome(options=self.get_options(), port=12345)
+        # Selenium 3.x stores socket._GLOBAL_DEFAULT_TIMEOUT as the default
+        # timeout, but urllib3 2.x (used with Python 3.14) cannot convert that
+        # sentinel object to float. Set an explicit timeout to avoid the error.
+        from selenium.webdriver.remote.remote_connection import RemoteConnection
+        if not isinstance(RemoteConnection._timeout, (int, float)) and RemoteConnection._timeout is not None:
+            RemoteConnection.set_timeout(60)
+        self.br = webdriver.Chrome(options=self.get_options())
 
     def get_options(self):
         options = Options()
-        options.add_argument("window-size=990,1200")
+        options.add_argument("--window-size=990,1200")
+
+        # Spoof a real browser UA so sites like HDFC don't serve degraded
+        # pages when they detect the "HeadlessChrome" user-agent string.
+        options.add_argument(
+            "--user-agent=Mozilla/5.0 (X11; Linux x86_64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/121.0.0.0 Safari/537.36"
+        )
+
         if not frappe.conf.developer_mode:
-            options.add_argument("--headless")
-            options.add_experimental_option("w3c", False)
+            # Use the modern headless mode (Chrome 112+) for a proper
+            # rendering pipeline instead of the legacy --headless flag.
+            options.add_argument("--headless=new")
+            # Required on Linux for stable headless operation.
+            options.add_argument("--no-sandbox")
+            options.add_argument("--disable-dev-shm-usage")
+            options.add_argument("--disable-gpu")
 
         return options
 

--- a/bank_integration/bank_integration/api/bank_api.py
+++ b/bank_integration/bank_integration/api/bank_api.py
@@ -59,7 +59,7 @@ class BankAPI:
         # sentinel object to float. Set an explicit timeout to avoid the error.
         from selenium.webdriver.remote.remote_connection import RemoteConnection
         if not isinstance(RemoteConnection._timeout, (int, float)) and RemoteConnection._timeout is not None:
-            RemoteConnection.set_timeout(60)
+            RemoteConnection.set_timeout(90)
         self.br = webdriver.Chrome(options=self.get_options())
 
     def get_options(self):
@@ -74,7 +74,7 @@ class BankAPI:
             "Chrome/121.0.0.0 Safari/537.36"
         )
 
-        if not frappe.conf.developer_mode:
+        if frappe.conf.developer_mode:
             # Use the modern headless mode (Chrome 112+) for a proper
             # rendering pipeline instead of the legacy --headless flag.
             options.add_argument("--headless=new")

--- a/bank_integration/bank_integration/api/bank_api.py
+++ b/bank_integration/bank_integration/api/bank_api.py
@@ -20,7 +20,7 @@ class BankAPI:
         self,
         username=None,
         password=None,
-        timeout=30,
+        timeout=10,
         logged_in=0,
         doctype=None,
         docname=None,
@@ -69,7 +69,7 @@ class BankAPI:
             "Chrome/121.0.0.0 Safari/537.36"
         )
 
-        if frappe.conf.developer_mode:
+        if not frappe.conf.developer_mode:
             options.add_argument("--headless=new")
             options.add_argument("--no-sandbox")
             options.add_argument("--disable-dev-shm-usage")

--- a/bank_integration/bank_integration/api/bank_api.py
+++ b/bank_integration/bank_integration/api/bank_api.py
@@ -20,7 +20,7 @@ class BankAPI:
         self,
         username=None,
         password=None,
-        timeout=10,
+        timeout=30,
         logged_in=0,
         doctype=None,
         docname=None,

--- a/bank_integration/bank_integration/api/bank_api.py
+++ b/bank_integration/bank_integration/api/bank_api.py
@@ -69,7 +69,7 @@ class BankAPI:
             "Chrome/121.0.0.0 Safari/537.36"
         )
 
-        if frappe.conf.developer_mode:
+        if not frappe.conf.developer_mode:
             options.add_argument("--headless=new")
             options.add_argument("--no-sandbox")
             options.add_argument("--disable-dev-shm-usage")

--- a/bank_integration/bank_integration/api/bank_api.py
+++ b/bank_integration/bank_integration/api/bank_api.py
@@ -54,9 +54,6 @@ class BankAPI:
         pass
 
     def setup_browser(self):
-        # Selenium 3.x stores socket._GLOBAL_DEFAULT_TIMEOUT as the default
-        # timeout, but urllib3 2.x (used with Python 3.14) cannot convert that
-        # sentinel object to float. Set an explicit timeout to avoid the error.
         from selenium.webdriver.remote.remote_connection import RemoteConnection
         if not isinstance(RemoteConnection._timeout, (int, float)) and RemoteConnection._timeout is not None:
             RemoteConnection.set_timeout(90)
@@ -66,19 +63,14 @@ class BankAPI:
         options = Options()
         options.add_argument("--window-size=990,1200")
 
-        # Spoof a real browser UA so sites like HDFC don't serve degraded
-        # pages when they detect the "HeadlessChrome" user-agent string.
         options.add_argument(
             "--user-agent=Mozilla/5.0 (X11; Linux x86_64) "
             "AppleWebKit/537.36 (KHTML, like Gecko) "
             "Chrome/121.0.0.0 Safari/537.36"
         )
 
-        if frappe.conf.developer_mode:
-            # Use the modern headless mode (Chrome 112+) for a proper
-            # rendering pipeline instead of the legacy --headless flag.
+        if not frappe.conf.developer_mode:
             options.add_argument("--headless=new")
-            # Required on Linux for stable headless operation.
             options.add_argument("--no-sandbox")
             options.add_argument("--disable-dev-shm-usage")
             options.add_argument("--disable-gpu")

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -12,12 +12,10 @@ from frappe.utils.file_manager import save_file
 from bank_integration.bank_integration.api.bank_api import BankAPI, AnyEC
 
 # Selenium imports
-from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
 from selenium.common.exceptions import (
     NoAlertPresentException,
-    NoSuchElementException,
     TimeoutException,
 )
 from selenium.webdriver.common.keys import Keys
@@ -170,7 +168,7 @@ class HDFCBankAPI(BankAPI):
             get_otp_btn.click()
         elif "mfa-get-otp-btn" == self.br._found_element[-1]:
             try:
-                email_mobile_otp_radio = self.get_element("channel-BOTH", "id")
+                email_mobile_otp_radio = self.get_element("channel-BOTH", "id",now=True)
                 email_mobile_otp_radio.click()
             except Exception:
                 pass
@@ -254,7 +252,7 @@ class HDFCBankAPI(BankAPI):
             self.submit_answers(answers)
 
     def submit_otp(self, otp):
-        otp_field = self.get_element("otpValue", "id")
+        otp_field = self.get_element("otpValue", "id",now = True)
         otp_field.send_keys(otp)
         submit_btn = self.get_element(
             '//button[contains(@class, "bb-button-bar__button") and contains(@class, "btn-primary") and normalize-space(text())="Submit"]',
@@ -344,13 +342,16 @@ class HDFCBankAPI(BankAPI):
         to_account_input_box = self.get_element("typeahead-template", "id")
         to_account_input_box.click()
         to_account_input_box.send_keys(self.data.to_account, Keys.ENTER)
-        option = self.wait_until(
-            EC.element_to_be_clickable(
-                (By.CSS_SELECTOR, "li.custom-to-account div.select-account-body")
-            ),
-            timeout=10,
-        )
-        option.click()
+        try:
+            option = self.wait_until(
+                EC.element_to_be_clickable(
+                    (By.CSS_SELECTOR, "li.custom-to-account div.select-account-body")
+                ),
+                timeout=10,
+            )
+            option.click()
+        except Exception:
+            self.throw("Could not find party's bank account in the list of Payees. Please add it manually")
 
         self._select_from_account_if_needed()
 
@@ -389,9 +390,7 @@ class HDFCBankAPI(BankAPI):
         if already_selected:
             selected_text = already_selected[0].text or ""
             last4 = self.data.from_account.strip().replace(" ", "")[-4:]
-            if last4 and (
-                last4 in selected_text.replace(" ", "")
-            ):
+            if last4 and (last4 in selected_text.replace(" ", "")):
                 return
 
         self.show_msg("Selecting from account...")

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -70,9 +70,15 @@ class HDFCBankAPI(BankAPI):
                     EC.visibility_of_element_located((By.ID, "proceedBtn")),
                     EC.visibility_of_element_located((By.ID, "mfa-get-otp-btn")),
                     EC.presence_of_element_located((By.TAG_NAME, "bb-retail-layout")),
+                    EC.visibility_of_element_located((By.NAME, "fldOldPass")),
+                    EC.visibility_of_element_located((By.NAME, "fldAnswer")),
                 ),
                 throw="ignore",
             )
+            # NOTE: The 'fldOldPass' and 'fldAnswer' conditions are not hit in the
+            # current HDFC UI. We still include them here so future maintainers know
+            # there is existing logic to handle password‑expiry and security‑question
+            # screens if the bank reintroduces them.
             found = self.br._found_element
 
             if not found:
@@ -106,6 +112,10 @@ class HDFCBankAPI(BankAPI):
                 self.process_security_questions()
                 return
 
+            elif last == "mfa-get-otp-btn":
+                self.process_otp()
+                return
+
             elif last == "bb-retail-layout":
                 if self.br.find_elements(By.ID, "mfa-get-otp-btn"):
                     self.process_otp()
@@ -134,7 +144,7 @@ class HDFCBankAPI(BankAPI):
                 ),
                 throw=False,
             )
-        except:
+        except Exception:
             self.throw(
                 "Failed to find Get Otp Button. Payment is not successful.",
                 screenshot=True,
@@ -296,19 +306,23 @@ class HDFCBankAPI(BankAPI):
 
     def logout(self):
         if self.logged_in:
-            logout_btn1 = self.br.find_element(
-                By.CSS_SELECTOR,
-                'div.logout-icon-container[aria-label="Logout"][role="button"]',
-            )
-            self.br.execute_script("arguments[0].click();", logout_btn1)
-            self.br.switch_to.default_content()
-            logout_btn2 = self.br.find_element(
-                By.XPATH,
-                '//button[contains(@class,"bb-button-bar__button") and normalize-space(text())="Logout"]',
-            )
-            self.br.execute_script("arguments[0].click();", logout_btn2)
-            time.sleep(1)
-
+            try:
+                logout_btn1 = self.br.find_element(
+                    By.CSS_SELECTOR,
+                    'div.logout-icon-container[aria-label="Logout"][role="button"]',
+                )
+                self.br.execute_script("arguments[0].click();", logout_btn1)
+                self.br.switch_to.default_content()
+                logout_btn2 = self.br.find_element(
+                    By.XPATH,
+                    '//button[contains(@class,"bb-button-bar__button") and normalize-space(text())="Logout"]',
+                )
+                self.br.execute_script("arguments[0].click();", logout_btn2)
+                time.sleep(1)
+            except Exception:
+                self.show_msg(
+                    "We were unable to complete the logout process on the bank website. Please manually log out from your online banking account to end the session safely."
+                )
         self.delete_cache()
         self.br.quit()
 
@@ -329,11 +343,11 @@ class HDFCBankAPI(BankAPI):
         to_account_input_box = self.get_element("typeahead-template", "id")
         to_account_input_box.click()
         to_account_input_box.send_keys(self.data.to_account, Keys.ENTER)
-        wait = WebDriverWait(self.br, 10)
-        option = wait.until(
+        option = self.wait_until(
             EC.element_to_be_clickable(
                 (By.CSS_SELECTOR, "li.custom-to-account div.select-account-body")
-            )
+            ),
+            timeout=10,
         )
         option.click()
 
@@ -357,7 +371,7 @@ class HDFCBankAPI(BankAPI):
         are masked (e.g. "**** **** **26 18"), so we match using the last 4
         digits of self.data.from_account.
         """
-        time.sleep(1)  
+        time.sleep(1)
 
         from_account_selectors = self.br.find_elements(
             By.CSS_SELECTOR, 'ng-select[name="bb-custom-account-selector"]'
@@ -374,14 +388,16 @@ class HDFCBankAPI(BankAPI):
         if already_selected:
             selected_text = already_selected[0].text or ""
             last4 = self.data.from_account.strip().replace(" ", "")[-4:]
-            if last4 and last4[-2:] in selected_text:
+            if last4 and (
+                last4 in selected_text.replace(" ", "") or last4[-2:] in selected_text
+            ):
                 return
 
         self.show_msg("Selecting from account...")
 
         account_stripped = self.data.from_account.strip().replace(" ", "")
-        last4 = account_stripped[-4:] 
-        last4_spaced = last4[-4:-2] + " " + last4[-2:]  
+        last4 = account_stripped[-4:]
+        last4_spaced = last4[-4:-2] + " " + last4[-2:]
 
         try:
             select_container = from_account_select.find_element(
@@ -391,12 +407,12 @@ class HDFCBankAPI(BankAPI):
         except Exception:
             self.br.execute_script("arguments[0].click();", from_account_select)
 
-        wait = WebDriverWait(self.br, 10)
         try:
-            wait.until(
+            self.wait_until(
                 EC.presence_of_element_located(
                     (By.CSS_SELECTOR, "ng-dropdown-panel div.ng-option")
-                )
+                ),
+                timeout=10,
             )
         except TimeoutException:
             self.throw(
@@ -405,7 +421,7 @@ class HDFCBankAPI(BankAPI):
                 screenshot=True,
             )
 
-        time.sleep(0.5)  
+        time.sleep(1)
 
         dropdown_options = self.br.find_elements(
             By.CSS_SELECTOR, "ng-dropdown-panel div.ng-option"
@@ -543,7 +559,7 @@ class HDFCBankAPI(BankAPI):
                 ),
                 throw=False,
             )
-        except:
+        except Exception:
             self.throw(
                 "Failed to find indication of successful payment. Please check if payment has been processed manually.",
                 screenshot=True,
@@ -610,7 +626,7 @@ class HDFCBankAPI(BankAPI):
                 ),
                 throw=False,
             )
-        except:
+        except Exception:
             self.throw(
                 "Failed to find indication of successful payment. Please check if payment has been processed manually.",
                 screenshot=True,
@@ -654,16 +670,14 @@ class HDFCBankAPI(BankAPI):
             self.br.switch_to.default_content()
 
             if self.data.transfer_type == "Transfer within the bank":
-                self.get_element("span.success-tick", "css_selector")
+                self.get_element("span.success-tick", "css_selector", throw=False)
 
             elif self.data.transfer_type == "Transfer to other bank (NEFT)":
-                self.get_element("span.success-tick", "css_selector")
+                self.get_element("span.success-tick", "css_selector", throw=False)
 
         except TimeoutException:
             self.throw(
-                "{} authentication failed. Exiting..".format(
-                    "OTP" if otp else "Security questions"
-                ),
+                "We could not detect a payment success confirmation on the bank website. Please verify whether the payment went through, either directly on the bank portal or using the attached screenshot.",
                 screenshot=True,
             )
         else:

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -406,7 +406,7 @@ class HDFCBankAPI(BankAPI):
 
     def logout(self):
         if self.logged_in:
-            self.br.switch_to.default_content()
+            # self.br.switch_to.default_content()
             logout_btn1 = self.br.find_element(
                 By.CSS_SELECTOR,
                 'div.logout-icon-container[aria-label="Logout"][role="button"]',
@@ -454,10 +454,189 @@ class HDFCBankAPI(BankAPI):
         )
         option.click()
 
+        # After selecting the to-account, handle from-account selection
+        # if the user has child/parent accounts.
+        self._select_from_account_if_needed()
+
         if self.data.transfer_type == "Transfer within the bank":
             self.make_payment_within_bank()
         elif self.data.transfer_type == "Transfer to other bank (NEFT)":
             self.make_neft_payment()
+
+    def _select_from_account_if_needed(self):
+        """
+        After the to-account is selected, HDFC may show an ng-select dropdown
+        for the from-account if the user has child/parent accounts.
+        If there is only one account (no child/parent), the website auto-sets
+        the from-account and no dropdown appears.
+
+        The dropdown has NO search input — it renders a flat list of
+        div.ng-option elements each containing a
+        bb-custom-product-item-basic-account-ui component.  Account numbers
+        are masked (e.g. "**** **** **26 18"), so we match using the last 4
+        digits of self.data.from_account.
+        """
+        time.sleep(1)  # Allow Angular to render the from-account section
+
+        # Check if the from-account ng-select dropdown is present on the page
+        from_account_selectors = self.br.find_elements(
+            By.CSS_SELECTOR, 'ng-select[name="bb-custom-account-selector"]'
+        )
+
+        if not from_account_selectors:
+            # No from-account selector found — website auto-set the account
+            return
+
+        from_account_select = from_account_selectors[0]
+
+        # Check if an account is already auto-selected by looking for the
+        # ng-value element (present when a value is chosen).  If the
+        # placeholder "Select an A/c" is visible instead, we need to select.
+        already_selected = from_account_select.find_elements(
+            By.CSS_SELECTOR, "div.ng-value:not(.ng-placeholder)"
+        )
+        if already_selected:
+            # Verify the already-selected account contains our last-4 digits
+            selected_text = already_selected[0].text or ""
+            last4 = self.data.from_account.strip().replace(" ", "")[-4:]
+            if last4 and last4[-2:] in selected_text:
+                return
+            # Wrong account pre-selected — fall through to re-select
+
+        self.show_msg("Selecting from account...")
+
+        # Extract the last 4 digits from the full account number for matching.
+        # HDFC masks the number as "**** **** **XX YY" where XXYY are the
+        # last 4 digits of the real account number, shown as two pairs
+        # separated by a space (e.g. account 50200012342618 → "26 18").
+        account_stripped = self.data.from_account.strip().replace(" ", "")
+        last4 = account_stripped[-4:]  # e.g. "2618"
+        last4_spaced = last4[-4:-2] + " " + last4[-2:]  # e.g. "26 18"
+
+        # Click the ng-select container to open the dropdown panel
+        try:
+            select_container = from_account_select.find_element(
+                By.CSS_SELECTOR, "div.ng-select-container"
+            )
+            select_container.click()
+        except Exception:
+            self.br.execute_script("arguments[0].click();", from_account_select)
+
+        # Wait for the dropdown options to appear
+        wait = WebDriverWait(self.br, 10)
+        try:
+            wait.until(
+                EC.presence_of_element_located(
+                    (By.CSS_SELECTOR, "ng-dropdown-panel div.ng-option")
+                )
+            )
+        except TimeoutException:
+            self.throw(
+                "From account selector appeared but the dropdown did not open. "
+                "Please check if the HDFC portal layout has changed.",
+                screenshot=True,
+            )
+
+        time.sleep(0.5)  # Let Angular finish rendering all options
+
+        # Collect all option elements from the dropdown
+        dropdown_options = self.br.find_elements(
+            By.CSS_SELECTOR, "ng-dropdown-panel div.ng-option"
+        )
+
+        if not dropdown_options:
+            self.throw(
+                "From account dropdown opened but contains no options.",
+                screenshot=True,
+            )
+
+        # ── Match and click ──────────────────────────────────────────────
+        # The visible text for each option looks like:
+        #   "Savings A/C  **** **** **26 18\nSMIT NALIN VORA\nAvailable Balance ₹1,91,030.64"
+        # We match against the last4 digits in both spaced ("26 18") and
+        # unspaced ("2618") forms, plus also try the full account number
+        # in case the portal shows it unmasked for some users.
+        option_found = False
+
+        for opt in dropdown_options:
+            opt_text = opt.text or ""
+            # Also grab the inner HTML in case visible text is incomplete
+            opt_html = opt.get_attribute("innerHTML") or ""
+
+            if (
+                last4_spaced in opt_text
+                or last4 in opt_text.replace(" ", "")
+                or self.data.from_account in opt_text
+                or last4_spaced in opt_html
+                or last4 in opt_html.replace(" ", "")
+            ):
+                # Prefer a normal Selenium click on the div.ng-option
+                try:
+                    opt.click()
+                except Exception:
+                    self.br.execute_script("arguments[0].click();", opt)
+                option_found = True
+                break
+
+        # Fallback: pure JS walk (covers edge cases where Selenium
+        # find_elements returned stale references after Angular re-render)
+        if not option_found:
+            try:
+                clicked = self.br.execute_script(
+                    """
+                    var options = document.querySelectorAll(
+                        'ng-dropdown-panel div.ng-option'
+                    );
+                    var last4Spaced = arguments[0];
+                    var last4       = arguments[1];
+                    var fullAcct    = arguments[2];
+                    for (var i = 0; i < options.length; i++) {
+                        var txt  = options[i].textContent || '';
+                        var html = options[i].innerHTML   || '';
+                        if (
+                            txt.indexOf(last4Spaced) !== -1 ||
+                            txt.replace(/ /g, '').indexOf(last4) !== -1 ||
+                            txt.indexOf(fullAcct) !== -1 ||
+                            html.indexOf(last4Spaced) !== -1 ||
+                            html.replace(/ /g, '').indexOf(last4) !== -1
+                        ) {
+                            options[i].click();
+                            return true;
+                        }
+                    }
+                    return false;
+                """,
+                    last4_spaced,
+                    last4,
+                    self.data.from_account,
+                )
+                if clicked:
+                    option_found = True
+            except Exception:
+                pass
+
+        if not option_found:
+            self.throw(
+                "Could not find from-account ending in '{}' in the account selector "
+                "dropdown. Please verify the account number in Bank Integration "
+                "Settings.".format(last4_spaced),
+                screenshot=True,
+            )
+
+        # Wait briefly for Angular to process the selection
+        time.sleep(1)
+
+        # Verify the selection stuck — the ng-value should now be present
+        # and the placeholder "Select an A/c" should be gone.
+        selected_values = from_account_select.find_elements(
+            By.CSS_SELECTOR, "div.ng-value:not(.ng-placeholder)"
+        )
+        if not selected_values:
+            self.throw(
+                "From account selection did not register. "
+                "The dropdown may have closed without selecting an account.",
+                screenshot=True,
+            )
 
     def make_payment_within_bank(self):
         # self.br.execute_script("return formSubmit_new('TPT');")
@@ -802,13 +981,12 @@ class HDFCBankAPI(BankAPI):
             except Exception:
                 pass
         else:
-            # Fallback for old NEFT UI (Reference Number in <td>)
-            # if ref_no == "-" and self.data.transfer_type == "Transfer to other bank (NEFT)":
             try:
                 ref_no = (
                     self.get_element(
-                        '//div[contains(@class,"bb-support--sub-title") and normalize-space(text())="Reference ID"]/following-sibling::div[contains(@class,"bb-text-medium-bold")]',
+                        '//div[contains(@class,"bb-support--subtitle") and contains(normalize-space(text()),"Reference")]/following-sibling::div[contains(@class,"bb-text-medium-bold")]',
                         "xpath",
+                        throw=False,
                     ).text
                     or "-"
                 ).strip()

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -72,6 +72,7 @@ class HDFCBankAPI(BankAPI):
                     EC.visibility_of_element_located((By.NAME, "fldAnswer")),
                 ),
                 throw="ignore",
+                timeout=10,
             )
             # NOTE: The 'fldOldPass' and 'fldAnswer' conditions are not hit in the
             # current HDFC UI. We still include them here so future maintainers know

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -414,7 +414,6 @@ class HDFCBankAPI(BankAPI):
                     (By.CSS_SELECTOR, "ng-dropdown-panel div.ng-option")
                 ),
                 timeout=10,
-                throw=False
             )
         except TimeoutException:
             self.throw(

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -252,8 +252,18 @@ class HDFCBankAPI(BankAPI):
             self.submit_answers(answers)
 
     def submit_otp(self, otp):
-        otp_field = self.get_element("otpValue", "id",now = True)
+        # There can be multiple #otpValue elements in the DOM (one hidden
+        # behind the modal, one visible inside it). Pick the visible one.
+        otp_field = self.br.execute_script("""
+            var fields = document.querySelectorAll('#otpValue');
+            for (var i = 0; i < fields.length; i++) {
+                var r = fields[i].getBoundingClientRect();
+                if (r.width > 0 && r.height > 0) return fields[i];
+            }
+            return fields[fields.length - 1];
+        """)
         otp_field.send_keys(otp)
+        self.br.switch_to.default_content()
         submit_btn = self.get_element(
             '//button[contains(@class, "bb-button-bar__button") and contains(@class, "btn-primary") and normalize-space(text())="Submit"]',
             "xpath",

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -36,98 +36,263 @@ class HDFCBankAPI(BankAPI):
         cust_id = self.get_element("fldLoginUserId")
         cust_id.send_keys(self.username, Keys.ENTER)
 
-        pass_input = self.get_element("fldPassword")
+        # After submitting the customer ID, HDFC removes all iframes and renders
+        # the password screen directly in the main document. Switch back out.
+        self.br.switch_to.default_content()
+        pass_input = self.get_element("password", "id")
+        # try:
+        #     secure_access_cb = self.get_element(
+        #         "chkrsastu", "id", timeout=2, throw=False
+        #     )
+        #     secure_access_cb.click()
+        # except TimeoutException:
+        #     pass
 
-        try:
-            secure_access_cb = self.get_element(
-                "chkrsastu", "id", timeout=2, throw=False
-            )
-            secure_access_cb.click()
-        except TimeoutException:
-            pass
+        # try:
+        #     self.get_element("fldCaptcha", timeout=1, throw=False)
+        # except TimeoutException:
+        #     pass
+        # else:
+        #     self.throw(
+        #         "HDFC Netbanking is asking for a CAPTCHA, which we don't currently support. Exiting."
+        #     )
 
-        try:
-            self.get_element("fldCaptcha", timeout=1, throw=False)
-        except TimeoutException:
-            pass
-        else:
-            self.throw(
-                "HDFC Netbanking is asking for a CAPTCHA, which we don't currently support. Exiting."
-            )
+        # Inject a MutationObserver BEFORE pressing Enter so that any
+        # element appearing transiently during Angular's page transition
+        # (e.g. OTP screen visible for < 500ms) is still recorded even
+        # if Selenium's 500ms poll cycle misses it entirely.
+        # Watches both DOM additions AND style/class attribute changes so
+        # it only records an element when it is actually visible on screen.
+        self.br.execute_script("""
+            window._hdfcSeenIds = new Set();
+            function checkVisible(id) {
+                var el = document.getElementById(id);
+                if (el) {
+                    var s = window.getComputedStyle(el);
+                    if (s.display !== 'none' && s.visibility !== 'hidden' && s.opacity !== '0') {
+                        window._hdfcSeenIds.add(id);
+                    }
+                }
+            }
+            var obs = new MutationObserver(function() {
+                ['mfa-get-otp-btn', 'proceedBtn'].forEach(checkVisible);
+            });
+            obs.observe(document.documentElement, {
+                childList: true,
+                subtree: true,
+                attributes: true,
+                attributeFilter: ['style', 'class', 'hidden']
+            });
+            window._hdfcObserver = obs;
+        """)
 
         pass_input.send_keys(self.password, Keys.ENTER)
 
-        self.wait_until(
-            AnyEC(
-                EC.visibility_of_element_located(
-                    (
-                        By.XPATH,
-                        "//td/span[text()[contains(.,'The Customer ID/IPIN (Password) is invalid.')]]",
-                    )
-                ),
-                EC.visibility_of_element_located((By.NAME, "fldOldPass")),
-                EC.visibility_of_element_located((By.NAME, "fldMobile")),
-                EC.visibility_of_element_located((By.NAME, "fldAnswer")),
-                EC.visibility_of_element_located((By.NAME, "common_menu1")),
-            ),
-            throw="ignore",
+        self.br.switch_to.default_content()
+        self._handle_post_login_state()
+
+    def _handle_post_login_state(self):
+        """
+        After password submission, HDFC can land on different screens:
+          1. Invalid credentials error
+          2. Password expired screen (fldOldPass)
+          3. "Already logged in" dialog with a Proceed button (proceedBtn).
+             This dialog can appear up to 2 times back-to-back.
+          4. OTP screen (mfa-get-otp-btn)
+          5. Security questions screen (fldAnswer)
+          6. Angular dashboard (bb-retail-layout tag) — direct login success
+        We loop up to 3 times so we can dismiss up to 2 proceed dialogs before
+        reaching the final state.
+        """
+        # Stop the observer and retrieve which element ids were seen
+        # transiently during Angular's page transition after password submit.
+        seen_transiently = set(
+            self.br.execute_script("""
+            if (window._hdfcObserver) { window._hdfcObserver.disconnect(); }
+            return window._hdfcSeenIds ? Array.from(window._hdfcSeenIds) : [];
+        """)
+            or []
         )
 
-        if not self.br._found_element:
-            self.handle_login_error()
+        for _ in range(3):
+            self.wait_until(
+                AnyEC(
+                    EC.visibility_of_element_located(
+                        (
+                            By.XPATH,
+                            "//td/span[text()[contains(.,'The Customer ID/IPIN (Password) is invalid.')]]",
+                        )
+                    ),
+                    # EC.visibility_of_element_located((By.NAME, "fldOldPass")),
+                    EC.visibility_of_element_located((By.ID, "proceedBtn")),
+                    # visibility_of_element_located is correct here — only fires
+                    # when truly visible. Transient appearances missed by the
+                    # 500ms poll are caught by the MutationObserver above.
+                    EC.visibility_of_element_located((By.ID, "mfa-get-otp-btn")),
+                    # EC.visibility_of_element_located((By.NAME, "fldAnswer")),
+                    EC.presence_of_element_located((By.TAG_NAME, "bb-retail-layout")),
+                ),
+                throw="ignore",
+            )
+            found = self.br._found_element
 
-        elif "fldOldPass" == self.br._found_element[-1]:
-            self.throw(
-                (
+            if not found:
+                # wait_until timed out — check if the observer recorded any
+                # transient states that the poll cycle may have missed.
+                if "mfa-get-otp-btn" in seen_transiently and self.br.find_elements(
+                    By.ID, "mfa-get-otp-btn"
+                ):
+                    self.process_otp()
+                    return
+                if "proceedBtn" in seen_transiently and self.br.find_elements(
+                    By.ID, "proceedBtn"
+                ):
+                    self.br.find_element(By.ID, "proceedBtn").click()
+                    continue
+                self.handle_login_error()
+                return
+
+            last = found[-1]
+
+            if "is invalid" in last:
+                self.throw(
+                    "The password you've set in Bank Integration Settings is incorrect."
+                )
+
+            elif last == "fldOldPass":
+                self.throw(
                     "The password you've set has expired. "
                     "Please set a new password manually and update the same in Bank Integration Settings."
                 )
-            )
 
-        elif "is invalid" in self.br._found_element[-1]:
-            self.throw(
-                "The password you've set in Bank Integration Settings is incorrect."
-            )
+            elif last == "proceedBtn":
+                # "Already logged in" dialog — click Proceed and loop to
+                # detect what screen comes next.
+                self.get_element("proceedBtn", "id", now=True).click()
+                continue
 
-        elif "fldMobile" == self.br._found_element[-1]:
-            self.process_otp()
-        elif "fldAnswer" == self.br._found_element[-1]:
-            self.process_security_questions()
-        else:
-            self.login_success()
+            elif last == "mfa-get-otp-btn":
+                self.process_otp()
+                return
+
+            elif last == "fldAnswer":
+                self.process_security_questions()
+                return
+
+            elif last == "bb-retail-layout":
+                # bb-retail-layout is the Angular app shell — it may be present
+                # on the OTP screen too. Check explicitly before declaring success.
+                if self.br.find_elements(By.ID, "mfa-get-otp-btn"):
+                    self.process_otp()
+                else:
+                    self.login_success()
+                return
+
+            else:
+                # Unknown state
+                self.handle_login_error()
+                return
+
+        # Looped 3 times without reaching a terminal state
+        self.handle_login_error()
 
     def process_otp(self):
         mobile_no = email_id = None
-        self.get_element("fldMobile", now=True).click()
 
         try:
-            mobile_no = self.get_element(
-                '//*[@name="fldMobile"]/../following-sibling::td[last()]',
+            self.wait_until(
+                AnyEC(
+                    EC.visibility_of_element_located(
+                        (
+                            By.XPATH,
+                            '//button[contains(@class, "bb-button-bar__button") and contains(@class, "btn-primary") and normalize-space(text())="Get OTP"]',
+                        )
+                    ),
+                    # mfa-get-otp-btn is kept display:none by Angular — it exists in the
+                    # DOM immediately but is never visible, so presence_of_element_located
+                    # must be used here instead of visibility_of_element_located.
+                    EC.presence_of_element_located((By.ID, "mfa-get-otp-btn")),
+                ),
+                throw=False,
+            )
+        except:
+            self.throw(
+                "Failed to find Get Otp Button. Payment is not successful.",
+                screenshot=True,
+            )
+
+        if (
+            '//button[contains(@class, "bb-button-bar__button") and contains(@class, "btn-primary") and normalize-space(text())="Get OTP"]'
+            == self.br._found_element[-1]
+        ):
+            try:
+                # Click the label wrapping the "SMS + email" radio option.
+                # The <input type="radio"> is visually hidden (::before pseudo-element
+                # renders the circle), so clicking the <input> directly has no effect.
+                # Clicking the <label data-role="radio-group-option"> that wraps it
+                # is the correct trigger for Angular's radio-group component.
+                # We target the label whose child span contains both "SMS" and "email"
+                # to select the combined SMS+email OTP channel.
+                email_mobile_otp_label = self.get_element(
+                    '//label[@data-role="radio-group-option"][.//span[contains(text(),"SMS") and contains(text(),"email")]]',
+                    "xpath",
+                )
+                self.br.execute_script("arguments[0].click();", email_mobile_otp_label)
+            except Exception:
+                pass
+            get_otp_btn = self.get_element(
+                '//button[contains(@class, "bb-button-bar__button") and contains(@class, "btn-primary") and normalize-space(text())="Get OTP"]',
                 "xpath",
                 now=True,
-                throw=False,
-            ).text
-        except NoSuchElementException:
-            pass
+            )
+            get_otp_btn.click()
+        elif "mfa-get-otp-btn" == self.br._found_element[-1]:
+            try:
+                email_mobile_otp_radio = self.get_element("channel-BOTH", "id")
+                email_mobile_otp_radio.click()
+            except Exception:
+                pass
+            otp_btn = self.get_element("mfa-get-otp-btn", "id", now=True)
+            self.br.execute_script("arguments[0].click();", otp_btn)
 
+        # Button exists in DOM but display:none (Angular) — use JS click
+        # otp_btn = self.get_element("mfa-get-otp-btn", "id", now=True)
+        # self.br.execute_script("arguments[0].click();", otp_btn)
+
+        ## till here the workflow is working. cleaning needs to be done.
+
+        # try:
+        #     mobile_no = self.get_element(
+        #         '//*[@name="fldMobile"]/../following-sibling::td[last()]',
+        #         "xpath",
+        #         now=True,
+        #         throw=False,
+        #     ).text
+        # except NoSuchElementException:
+        #     pass
+
+        # try:
+        #     self.get_element("fldEmailid", now=True, throw=False).click()
+        #     email_id = self.get_element(
+        #         '//*[@name="fldEmailid"]/../following-sibling::td[last()]',
+        #         "xpath",
+        #         now=True,
+        #         throw=False,
+        #     ).text
+        # except NoSuchElementException:
+        #     pass
+        self.br.switch_to.default_content()
+        input_msg = ""
         try:
-            self.get_element("fldEmailid", now=True, throw=False).click()
-            email_id = self.get_element(
-                '//*[@name="fldEmailid"]/../following-sibling::td[last()]',
-                "xpath",
-                now=True,
-                throw=False,
-            ).text
-        except NoSuchElementException:
+            input_msg = self.get_element('label[for="otpValue"]', "css_selector").text
+        except Exception:
             pass
-
-        self.br.execute_script("return fireOtp();")
+        # self.br.execute_script("return fireOtp();")
 
         frappe.publish_realtime(
             "get_bank_otp",
             {
-                "mobile_no": mobile_no,
-                "email_id": email_id,
+                "message": input_msg,
                 "uid": self.uid,
                 "bank_name": self.bank_name,
                 "logged_in": self.logged_in,
@@ -156,8 +321,8 @@ class HDFCBankAPI(BankAPI):
         self.save_for_later()
 
     def get_question_map(self, get_fields=False):
-        question_elements = self.br.find_elements_by_name("fldQuestionText")
-        answer_elements = self.br.find_elements_by_name("fldAnswer")
+        question_elements = self.br.find_elements(By.NAME, "fldQuestionText")
+        answer_elements = self.br.find_elements(By.NAME, "fldAnswer")
 
         question_map = {}
         i = 0
@@ -188,9 +353,14 @@ class HDFCBankAPI(BankAPI):
             self.submit_answers(answers)
 
     def submit_otp(self, otp):
-        otp_field = self.get_element("fldOtpToken")
+        otp_field = self.get_element("otpValue", "id")
         otp_field.send_keys(otp)
-        self.br.execute_script("return authOtp();")
+        submit_btn = self.get_element(
+            '//button[contains(@class, "bb-button-bar__button") and contains(@class, "btn-primary") and normalize-space(text())="Submit"]',
+            "xpath",
+        )
+        submit_btn.click()
+        # self.br.execute_script("return authOtp();")
 
     def submit_answers(self, answers):
         field_map = self.get_question_map(True)
@@ -203,7 +373,11 @@ class HDFCBankAPI(BankAPI):
     def continue_login(self, otp=None, answers=None):
         self.submit_otp_or_answers(otp, answers)
         try:
-            self.get_element("common_menu1", throw=False)
+            self.get_element(
+                '//h1[@data-role="headings" and contains(@class,"bb-heading-widget__heading")]',
+                "xpath",
+                throw=False,
+            )
         except TimeoutException:
             self.handle_login_error()
         else:
@@ -232,19 +406,53 @@ class HDFCBankAPI(BankAPI):
 
     def logout(self):
         if self.logged_in:
-            self.switch_to_frame("common_menu1")
-            self.br.execute_script("return Logout();")
+            self.br.switch_to.default_content()
+            logout_btn1 = self.br.find_element(
+                By.CSS_SELECTOR,
+                'div.logout-icon-container[aria-label="Logout"][role="button"]',
+            )
+            self.br.execute_script("arguments[0].click();", logout_btn1)
+            self.br.switch_to.default_content()
+            logout_btn2 = self.br.find_element(
+                By.XPATH,
+                '//button[contains(@class,"bb-button-bar__button") and normalize-space(text())="Logout"]',
+            )
+            self.br.execute_script("arguments[0].click();", logout_btn2)
             time.sleep(1)
 
         self.delete_cache()
         self.br.quit()
 
     def make_payment(self):
-        self.switch_to_frame("common_menu1")
-        self.get_element("//a[@title='Funds Transfer']", "xpath", now=True).click()
+        self.br.switch_to.default_content()
 
-        self.switch_to_frame("main_part")
-        self.get_element("selectTPT", "class_name")
+        # Use a JS click on the Angular routerlink anchor instead of self.br.get()
+        # or a normal Selenium click. self.br.get() causes a full page reload which
+        # HDFC detects and terminates the session. A JS click fires the Angular
+        # router internally without any HTTP navigation, and works regardless of
+        # whether the element is visible or the navbar is collapsed.
+        clicked = self.br.execute_script("""
+            var el = document.querySelector("a[routerlink='/transfers/send-money']");
+            if (el) { el.click(); return true; }
+            return false;
+        """)
+        if not clicked:
+            self.throw(
+                "Could not find the 'Send Money' navigation link. The HDFC portal layout may have changed."
+            )
+
+        self.wait_until(EC.url_contains("/transfers/send-money"))
+
+        to_account_input_box = self.get_element("typeahead-template", "id")
+        to_account_input_box.click()
+        to_account_input_box.send_keys(self.data.to_account, Keys.ENTER)
+        wait = WebDriverWait(self.br, 10)
+        option = wait.until(
+            EC.element_to_be_clickable(
+                (By.CSS_SELECTOR, "li.custom-to-account div.select-account-body")
+            )
+        )
+        option.click()
 
         if self.data.transfer_type == "Transfer within the bank":
             self.make_payment_within_bank()
@@ -252,64 +460,98 @@ class HDFCBankAPI(BankAPI):
             self.make_neft_payment()
 
     def make_payment_within_bank(self):
-        self.br.execute_script("return formSubmit_new('TPT');")
+        # self.br.execute_script("return formSubmit_new('TPT');")
 
-        self.switch_to_frame("main_part")
-        self.get_element("selectselAcct0", "id")
+        # self.switch_to_frame("main_part")
+        # self.get_element("selectselAcct0", "id")
 
-        # from account
-        from_account = self.get_element("selAcct", now=True)
-        self.click_option(
-            from_account,
-            self.data.from_account,
-            "The account number you entered in Bank Integration Settings could not be found in NetBanking",
-        )
+        # # from account
+        # from_account = self.get_element("selAcct", now=True)
+        # self.click_option(
+        #     from_account,
+        #     self.data.from_account,
+        #     "The account number you entered in Bank Integration Settings could not be found in NetBanking",
+        # )
 
         # to account
-        beneficiary = self.get_element("fldToAcct", now=True)
-        self.click_option(
-            beneficiary,
-            self.data.to_account,
-            "Unable to find a beneficiary associated with the party's account number",
-        )
-
-        # description
-        desc = self.get_element("transferDtls", now=True)
-        desc.clear()
-        desc.send_keys(self.data.payment_desc)
-
+        # beneficiary = self.get_element("fldToAcct", now=True)
+        # self.click_option(
+        #     beneficiary,
+        #     self.data.to_account,
+        #     "Unable to find a beneficiary associated with the party's account number",
+        # )
         # amount
-        amt = self.get_element("transferAmt", now=True)
+        amt = self.get_element("transfer-amount-input", "id")
         amt.clear()
         amt.send_keys("%.2f" % self.data.amount)
 
+        # description - target the actual input inside the cb-input-text-ui wrapper
+        # desc = self.get_element("cb-input-text-ui#note input", "css_selector", now=True)
+        desc = self.get_element('input[data-role="input"]', "css_selector")
+        desc.clear()
+        desc.send_keys(self.data.payment_desc)
+
         # continue
-        self.br.execute_script("return onSubmit();")
+        continue_btn = self.get_element(
+            'button[type="submit"].btn-primary.btn.btn-md.btn-block',
+            "css_selector",
+            now=True,
+        )
+        self.br.execute_script("arguments[0].scrollIntoView({block: 'center'});", continue_btn)
+        try:
+            continue_btn.click()
+        except Exception:
+            self.br.execute_script("arguments[0].click();", continue_btn)
 
-        # confirm
-        self.switch_to_frame("main_part")
-        self.br.execute_script("return issue_click();")
+        # Terms & conditions checkbox
+        checkbox_label = self.get_element(
+            'span.bb-input-checkbox__content[data-role="checkbox-label"]',
+            "css_selector",
+        )
+        checkbox_label.click()
 
-        self.switch_to_frame("main_part")
+        # Confirm
+        confirm_btn = self.get_element(
+            'button.confirm-btn[aria-label="Confirm Transfer"]',
+            "css_selector",
+        )
+        confirm_btn.click()
+        # self.switch_to_frame("main_part")
+        self.br.switch_to.default_content()
+
+        # self.br.execute_script("return issue_click();")
+
+        # self.switch_to_frame("main_part")
+
+        # get_otp_btn = self.get_element("", "xpath", now=True)
+        # get_otp_btn.click()
 
         try:
             self.wait_until(
                 AnyEC(
-                    EC.visibility_of_element_located((By.NAME, "fldMobile")),
+                    EC.visibility_of_element_located(
+                        (
+                            By.XPATH,
+                            '//button[contains(@class, "bb-button-bar__button") and contains(@class, "btn-primary") and normalize-space(text())="Get OTP"]',
+                        )
+                    ),
                     EC.visibility_of_element_located((By.NAME, "fldAnswer")),
                     EC.visibility_of_element_located(
-                        (By.XPATH, "//span[@class='successIcon']")
+                        (By.CSS_SELECTOR, "span.success-tick")
                     ),
                 ),
                 throw=False,
             )
         except:
             self.throw(
-                "Failed to find indication of successful payment. Please check is payment has been processed manually.",
+                "Failed to find indication of successful payment. Please check if payment has been processed manually.",
                 screenshot=True,
             )
 
-        if "fldMobile" == self.br._found_element[-1]:
+        if (
+            '//button[contains(@class, "bb-button-bar__button") and contains(@class, "btn-primary") and normalize-space(text())="Get OTP"]'
+            == self.br._found_element[-1]
+        ):
             self.process_otp()
         elif "fldAnswer" == self.br._found_element[-1]:
             self.process_security_questions()
@@ -317,107 +559,172 @@ class HDFCBankAPI(BankAPI):
             self.payment_success()
 
     def make_neft_payment(self):
-        self.br.execute_script("return formSubmit_new('NEFT');")
-
-        self.switch_to_frame("main_part")
-        self.get_element("selectselAcct0", "id")
-
-        # from account
-        from_account = self.get_element("selAcct", now=True)
-        self.click_option(
-            from_account,
-            self.data.from_account,
-            "The account number you entered in Bank Integration Settings could not be found in NetBanking",
-        )
-
-        # to account
-        try:
-            account_index = self.br.execute_script(
-                'return l_beneacct.indexOf("{}");'.format(self.data.to_account)
-            )
-        except:
-            self.throw("Failed to select beneficiary in Netbanking")
-
-        if account_index == -1:
-            self.throw("Beneficary account number not found in Netbanking")
-        else:
-            account_index = str(account_index)
-
-        beneficiary = self.get_element("fldBeneId", now=True)
-        self.click_option(
-            beneficiary,
-            account_index,
-            "Unable to find a beneficiary associated with the party's account number",
-            exact=True,
-        )
-
-        time.sleep(0.5)
-        if (
-            self.get_element("fldBeneAcct", now=True).get_attribute("value") or ""
-        ).strip() != self.data.to_account:
-            self.throw(
-                "Incorrect account selected. Please contact developer for support."
-            )
-
-        # description
-        desc = self.get_element("fldTxnDesc", now=True)
-        desc.clear()
-        desc.send_keys(self.data.payment_desc)
-
-        # amount
-        amt = self.get_element("fldTxnAmount", now=True)
+        # self.br.execute_script("return formSubmit_new('NEFT');")
+        amt = self.get_element("transfer-amount-input", "id")
         amt.clear()
         amt.send_keys("%.2f" % self.data.amount)
 
-        # communication type
-        comm_type = self.get_element("fldComMode", now=True)
-        self.click_option(
-            comm_type,
-            self.data.comm_type,
-            "Unable to select communication type in NEFT form",
-            compare_text=True,
-        )
-
-        # communication value
-        comm_value = self.get_element("fldMobileEmail", now=True)
-        comm_value.clear()
-        comm_value.send_keys(self.data.comm_value)
-
-        # accept terms
-        self.get_element(
-            "//*[@name='fldtc']/preceding-sibling::span[@class='checkbox']",
-            "xpath",
-            now=True,
-        ).click()
+        # description - target the actual input inside the cb-input-text-ui wrapper
+        # desc = self.get_element("cb-input-text-ui#note input", "css_selector", now=True)
+        desc = self.get_element('input[data-role="input"]', "css_selector")
+        desc.clear()
+        desc.send_keys(self.data.payment_desc)
 
         # continue
-        self.br.execute_script("return formSubmit();")
+        continue_btn = self.get_element(
+            'button[type="submit"][aria-label="Continue transfer"]',
+            "css_selector",
+            now=True,
+        )
+        self.br.execute_script(
+            "arguments[0].scrollIntoView({block: 'center'});", continue_btn
+        )
+        try:
+            continue_btn.click()
+        except Exception:
+            self.br.execute_script("arguments[0].click();", continue_btn)
 
-        # confirm
-        self.switch_to_frame("main_part")
-        self.br.execute_script("return formSubmit();")
+        # Terms & conditions checkbox
+        checkbox_label = self.get_element(
+            'span.bb-input-checkbox__content[data-role="checkbox-label"]',
+            "css_selector",
+        )
+        checkbox_label.click()
 
-        self.switch_to_frame("main_part")
+        # Confirm
+        confirm_btn = self.get_element(
+            'button.confirm-btn[aria-label="Confirm Transfer"]',
+            "css_selector",
+        )
+        confirm_btn.click()
+        # self.switch_to_frame("main_part")
+        self.br.switch_to.default_content()
 
         try:
             self.wait_until(
                 AnyEC(
-                    EC.visibility_of_element_located((By.NAME, "fldMobile")),
+                    EC.visibility_of_element_located(
+                        (
+                            By.XPATH,
+                            '//button[contains(@class, "bb-button-bar__button") and contains(@class, "btn-primary") and normalize-space(text())="Get OTP"]',
+                        )
+                    ),
                     EC.visibility_of_element_located((By.NAME, "fldAnswer")),
                     EC.visibility_of_element_located(
-                        (By.XPATH, "//td[contains(text(),'Reference Number')]")
+                        (By.CSS_SELECTOR, "span.success-tick")
                     ),
                 ),
                 throw=False,
             )
         except:
             self.throw(
-                "Failed to find indication of successful payment. Please check is payment has been processed manually.",
+                "Failed to find indication of successful payment. Please check if payment has been processed manually.",
                 screenshot=True,
             )
 
-        if "fldMobile" == self.br._found_element[-1]:
+        if (
+            '//button[contains(@class, "bb-button-bar__button") and contains(@class, "btn-primary") and normalize-space(text())="Get OTP"]'
+            == self.br._found_element[-1]
+        ):
             self.process_otp()
+
+        # self.switch_to_frame("main_part")
+        # self.get_element("selectselAcct0", "id")
+
+        # # from account
+        # from_account = self.get_element("selAcct", now=True)
+        # self.click_option(
+        #     from_account,
+        #     self.data.from_account,
+        #     "The account number you entered in Bank Integration Settings could not be found in NetBanking",
+        # )
+
+        # to account
+        # try:
+        #     account_index = self.br.execute_script(
+        #         'return l_beneacct.indexOf("{}");'.format(self.data.to_account)
+        #     )
+        # except:
+        #     self.throw("Failed to select beneficiary in Netbanking")
+
+        # if account_index == -1:
+        #     self.throw("Beneficary account number not found in Netbanking")
+        # else:
+        #     account_index = str(account_index)
+
+        # beneficiary = self.get_element("fldBeneId", now=True)
+        # self.click_option(
+        #     beneficiary,
+        #     account_index,
+        #     "Unable to find a beneficiary associated with the party's account number",
+        #     exact=True,
+        # )
+
+        # time.sleep(0.5)
+        # if (
+        #     self.get_element("fldBeneAcct", now=True).get_attribute("value") or ""
+        # ).strip() != self.data.to_account:
+        #     self.throw(
+        #         "Incorrect account selected. Please contact developer for support."
+        #     )
+
+        # # description
+        # desc = self.get_element("fldTxnDesc", now=True)
+        # desc.clear()
+        # desc.send_keys(self.data.payment_desc)
+
+        # # amount
+        # amt = self.get_element("fldTxnAmount", now=True)
+        # amt.clear()
+        # amt.send_keys("%.2f" % self.data.amount)
+
+        # communication type
+        # comm_type = self.get_element("fldComMode", now=True)
+        # self.click_option(
+        #     comm_type,
+        #     self.data.comm_type,
+        #     "Unable to select communication type in NEFT form",
+        #     compare_text=True,
+        # )
+
+        # # communication value
+        # comm_value = self.get_element("fldMobileEmail", now=True)
+        # comm_value.clear()
+        # comm_value.send_keys(self.data.comm_value)
+
+        # # accept terms
+        # self.get_element(
+        #     "//*[@name='fldtc']/preceding-sibling::span[@class='checkbox']",
+        #     "xpath",
+        #     now=True,
+        # ).click()
+
+        # # continue
+        # self.br.execute_script("return formSubmit();")
+
+        # # confirm
+        # self.switch_to_frame("main_part")
+        # self.br.execute_script("return formSubmit();")
+
+        # self.switch_to_frame("main_part")
+
+        # try:
+        #     self.wait_until(
+        #         AnyEC(
+        #             EC.visibility_of_element_located((By.NAME, "fldMobile")),
+        #             EC.visibility_of_element_located((By.NAME, "fldAnswer")),
+        #             EC.visibility_of_element_located(
+        #                 (By.XPATH, "//td[contains(text(),'Reference Number')]")
+        #             ),
+        #         ),
+        #         throw=False,
+        #     )
+        # except:
+        #     self.throw(
+        #         "Failed to find indication of successful payment. Please check is payment has been processed manually.",
+        #         screenshot=True,
+        #     )
+
         elif "fldAnswer" == self.br._found_element[-1]:
             self.process_security_questions()
         else:
@@ -426,7 +733,7 @@ class HDFCBankAPI(BankAPI):
     def click_option(
         self, element, to_click, error=None, exact=False, compare_text=False
     ):
-        for option in element.find_elements_by_tag_name("option"):
+        for option in element.find_elements(By.TAG_NAME, "option"):
             if not compare_text:
                 val = option.get_attribute("value")
             else:
@@ -444,19 +751,17 @@ class HDFCBankAPI(BankAPI):
                 self.throw(error)
 
     def continue_payment(self, otp=None, answers=None):
-        self.switch_to_frame("main_part")
+        self.br.switch_to.default_content()
         self.submit_otp_or_answers(otp, answers)
 
         try:
-            self.switch_to_frame("main_part")
+            self.br.switch_to.default_content()
 
             if self.data.transfer_type == "Transfer within the bank":
-                self.get_element("//span[@class='successIcon']", "xpath", throw=False)
+                self.get_element("span.success-tick", "css_selector")
 
             elif self.data.transfer_type == "Transfer to other bank (NEFT)":
-                self.get_element(
-                    "//td[contains(text(),'Reference Number')]", "xpath", throw=False
-                )
+                self.get_element("span.success-tick", "css_selector")
 
         except TimeoutException:
             self.throw(
@@ -469,7 +774,10 @@ class HDFCBankAPI(BankAPI):
             self.payment_success()
 
     def payment_success(self):
-        self.switch_to_frame("main_part")
+        self.br.switch_to.default_content()
+
+        details_button = self.get_element("showHideBtn", "id")
+        details_button.click()
 
         save_file(
             self.docname + " Online Payment Screenshot.png",
@@ -481,20 +789,31 @@ class HDFCBankAPI(BankAPI):
 
         ref_no = "-"
         if self.data.transfer_type == "Transfer within the bank":
-            ref_no = (
-                self.br.execute_script(
-                    "return $('table.transTable td:nth-child(3) > span').text();"
-                )
-                or "-"
-            )
-        elif self.data.transfer_type == "Transfer to other bank (NEFT)":
-            ref_no = (
-                self.get_element(
-                    "//td[contains(text(),'Reference Number')]/following-sibling::td[last()]",
-                    "xpath",
-                ).text
-                or "-"
-            ).strip()
+            try:
+                ref_no = (
+                    self.get_element(
+                        "//div[normalize-space(text())='Transaction ID']/following-sibling::div[contains(@class,'bb-text-medium-bold')]",
+                        "xpath",
+                        now=True,
+                        throw=False,
+                    ).text
+                    or "-"
+                ).strip()
+            except Exception:
+                pass
+        else:
+            # Fallback for old NEFT UI (Reference Number in <td>)
+            # if ref_no == "-" and self.data.transfer_type == "Transfer to other bank (NEFT)":
+            try:
+                ref_no = (
+                    self.get_element(
+                        '//div[contains(@class,"bb-support--sub-title") and normalize-space(text())="Reference ID"]/following-sibling::div[contains(@class,"bb-text-medium-bold")]',
+                        "xpath",
+                    ).text
+                    or "-"
+                ).strip()
+            except Exception:
+                pass
 
         frappe.publish_realtime(
             "payment_success",
@@ -605,7 +924,7 @@ class HDFCBankAPI(BankAPI):
                 from_date = prev_valid_date
             from_date = add_days(from_date, -1)
 
-        self.br.find_elements_by_class_name("radio")[1].click()
+        self.br.find_elements(By.CLASS_NAME, "radio")[1].click()
 
         self.get_element("frmDatePicker", selector_type="id", now=True).send_keys(
             getdate(from_date).strftime("%d/%m/%Y")
@@ -616,7 +935,7 @@ class HDFCBankAPI(BankAPI):
         self.br.execute_script("return formSubmitbytype()")
 
         self.br.execute_script("$('.datatable').show()")
-        transaction_tables = self.br.find_elements_by_class_name("datatable")
+        transaction_tables = self.br.find_elements(By.CLASS_NAME, "datatable")
 
         if not transaction_tables:
             self.throw("No New Transactions found")

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -36,55 +36,8 @@ class HDFCBankAPI(BankAPI):
         cust_id = self.get_element("fldLoginUserId")
         cust_id.send_keys(self.username, Keys.ENTER)
 
-        # After submitting the customer ID, HDFC removes all iframes and renders
-        # the password screen directly in the main document. Switch back out.
         self.br.switch_to.default_content()
         pass_input = self.get_element("password", "id")
-        # try:
-        #     secure_access_cb = self.get_element(
-        #         "chkrsastu", "id", timeout=2, throw=False
-        #     )
-        #     secure_access_cb.click()
-        # except TimeoutException:
-        #     pass
-
-        # try:
-        #     self.get_element("fldCaptcha", timeout=1, throw=False)
-        # except TimeoutException:
-        #     pass
-        # else:
-        #     self.throw(
-        #         "HDFC Netbanking is asking for a CAPTCHA, which we don't currently support. Exiting."
-        #     )
-
-        # Inject a MutationObserver BEFORE pressing Enter so that any
-        # element appearing transiently during Angular's page transition
-        # (e.g. OTP screen visible for < 500ms) is still recorded even
-        # if Selenium's 500ms poll cycle misses it entirely.
-        # Watches both DOM additions AND style/class attribute changes so
-        # it only records an element when it is actually visible on screen.
-        self.br.execute_script("""
-            window._hdfcSeenIds = new Set();
-            function checkVisible(id) {
-                var el = document.getElementById(id);
-                if (el) {
-                    var s = window.getComputedStyle(el);
-                    if (s.display !== 'none' && s.visibility !== 'hidden' && s.opacity !== '0') {
-                        window._hdfcSeenIds.add(id);
-                    }
-                }
-            }
-            var obs = new MutationObserver(function() {
-                ['mfa-get-otp-btn', 'proceedBtn'].forEach(checkVisible);
-            });
-            obs.observe(document.documentElement, {
-                childList: true,
-                subtree: true,
-                attributes: true,
-                attributeFilter: ['style', 'class', 'hidden']
-            });
-            window._hdfcObserver = obs;
-        """)
 
         pass_input.send_keys(self.password, Keys.ENTER)
 
@@ -104,15 +57,6 @@ class HDFCBankAPI(BankAPI):
         We loop up to 3 times so we can dismiss up to 2 proceed dialogs before
         reaching the final state.
         """
-        # Stop the observer and retrieve which element ids were seen
-        # transiently during Angular's page transition after password submit.
-        seen_transiently = set(
-            self.br.execute_script("""
-            if (window._hdfcObserver) { window._hdfcObserver.disconnect(); }
-            return window._hdfcSeenIds ? Array.from(window._hdfcSeenIds) : [];
-        """)
-            or []
-        )
 
         for _ in range(3):
             self.wait_until(
@@ -123,13 +67,8 @@ class HDFCBankAPI(BankAPI):
                             "//td/span[text()[contains(.,'The Customer ID/IPIN (Password) is invalid.')]]",
                         )
                     ),
-                    # EC.visibility_of_element_located((By.NAME, "fldOldPass")),
                     EC.visibility_of_element_located((By.ID, "proceedBtn")),
-                    # visibility_of_element_located is correct here — only fires
-                    # when truly visible. Transient appearances missed by the
-                    # 500ms poll are caught by the MutationObserver above.
                     EC.visibility_of_element_located((By.ID, "mfa-get-otp-btn")),
-                    # EC.visibility_of_element_located((By.NAME, "fldAnswer")),
                     EC.presence_of_element_located((By.TAG_NAME, "bb-retail-layout")),
                 ),
                 throw="ignore",
@@ -137,16 +76,10 @@ class HDFCBankAPI(BankAPI):
             found = self.br._found_element
 
             if not found:
-                # wait_until timed out — check if the observer recorded any
-                # transient states that the poll cycle may have missed.
-                if "mfa-get-otp-btn" in seen_transiently and self.br.find_elements(
-                    By.ID, "mfa-get-otp-btn"
-                ):
+                if self.br.find_elements(By.ID, "mfa-get-otp-btn"):
                     self.process_otp()
                     return
-                if "proceedBtn" in seen_transiently and self.br.find_elements(
-                    By.ID, "proceedBtn"
-                ):
+                if self.br.find_elements(By.ID, "proceedBtn"):
                     self.br.find_element(By.ID, "proceedBtn").click()
                     continue
                 self.handle_login_error()
@@ -166,22 +99,14 @@ class HDFCBankAPI(BankAPI):
                 )
 
             elif last == "proceedBtn":
-                # "Already logged in" dialog — click Proceed and loop to
-                # detect what screen comes next.
                 self.get_element("proceedBtn", "id", now=True).click()
                 continue
-
-            elif last == "mfa-get-otp-btn":
-                self.process_otp()
-                return
 
             elif last == "fldAnswer":
                 self.process_security_questions()
                 return
 
             elif last == "bb-retail-layout":
-                # bb-retail-layout is the Angular app shell — it may be present
-                # on the OTP screen too. Check explicitly before declaring success.
                 if self.br.find_elements(By.ID, "mfa-get-otp-btn"):
                     self.process_otp()
                 else:
@@ -189,15 +114,12 @@ class HDFCBankAPI(BankAPI):
                 return
 
             else:
-                # Unknown state
                 self.handle_login_error()
                 return
 
-        # Looped 3 times without reaching a terminal state
         self.handle_login_error()
 
     def process_otp(self):
-        mobile_no = email_id = None
 
         try:
             self.wait_until(
@@ -208,9 +130,6 @@ class HDFCBankAPI(BankAPI):
                             '//button[contains(@class, "bb-button-bar__button") and contains(@class, "btn-primary") and normalize-space(text())="Get OTP"]',
                         )
                     ),
-                    # mfa-get-otp-btn is kept display:none by Angular — it exists in the
-                    # DOM immediately but is never visible, so presence_of_element_located
-                    # must be used here instead of visibility_of_element_located.
                     EC.presence_of_element_located((By.ID, "mfa-get-otp-btn")),
                 ),
                 throw=False,
@@ -226,13 +145,6 @@ class HDFCBankAPI(BankAPI):
             == self.br._found_element[-1]
         ):
             try:
-                # Click the label wrapping the "SMS + email" radio option.
-                # The <input type="radio"> is visually hidden (::before pseudo-element
-                # renders the circle), so clicking the <input> directly has no effect.
-                # Clicking the <label data-role="radio-group-option"> that wraps it
-                # is the correct trigger for Angular's radio-group component.
-                # We target the label whose child span contains both "SMS" and "email"
-                # to select the combined SMS+email OTP channel.
                 email_mobile_otp_label = self.get_element(
                     '//label[@data-role="radio-group-option"][.//span[contains(text(),"SMS") and contains(text(),"email")]]',
                     "xpath",
@@ -255,39 +167,18 @@ class HDFCBankAPI(BankAPI):
             otp_btn = self.get_element("mfa-get-otp-btn", "id", now=True)
             self.br.execute_script("arguments[0].click();", otp_btn)
 
-        # Button exists in DOM but display:none (Angular) — use JS click
-        # otp_btn = self.get_element("mfa-get-otp-btn", "id", now=True)
-        # self.br.execute_script("arguments[0].click();", otp_btn)
-
-        ## till here the workflow is working. cleaning needs to be done.
-
-        # try:
-        #     mobile_no = self.get_element(
-        #         '//*[@name="fldMobile"]/../following-sibling::td[last()]',
-        #         "xpath",
-        #         now=True,
-        #         throw=False,
-        #     ).text
-        # except NoSuchElementException:
-        #     pass
-
-        # try:
-        #     self.get_element("fldEmailid", now=True, throw=False).click()
-        #     email_id = self.get_element(
-        #         '//*[@name="fldEmailid"]/../following-sibling::td[last()]',
-        #         "xpath",
-        #         now=True,
-        #         throw=False,
-        #     ).text
-        # except NoSuchElementException:
-        #     pass
         self.br.switch_to.default_content()
         input_msg = ""
-        try:
-            input_msg = self.get_element('label[for="otpValue"]', "css_selector").text
-        except Exception:
-            pass
-        # self.br.execute_script("return fireOtp();")
+        if (
+            '//button[contains(@class, "bb-button-bar__button") and contains(@class, "btn-primary") and normalize-space(text())="Get OTP"]'
+            == self.br._found_element[-1]
+        ):
+            try:
+                input_msg = self.get_element(
+                    'label[for="otpValue"]', "css_selector"
+                ).text
+            except Exception:
+                pass
 
         frappe.publish_realtime(
             "get_bank_otp",
@@ -360,7 +251,6 @@ class HDFCBankAPI(BankAPI):
             "xpath",
         )
         submit_btn.click()
-        # self.br.execute_script("return authOtp();")
 
     def submit_answers(self, answers):
         field_map = self.get_question_map(True)
@@ -406,7 +296,6 @@ class HDFCBankAPI(BankAPI):
 
     def logout(self):
         if self.logged_in:
-            # self.br.switch_to.default_content()
             logout_btn1 = self.br.find_element(
                 By.CSS_SELECTOR,
                 'div.logout-icon-container[aria-label="Logout"][role="button"]',
@@ -425,12 +314,6 @@ class HDFCBankAPI(BankAPI):
 
     def make_payment(self):
         self.br.switch_to.default_content()
-
-        # Use a JS click on the Angular routerlink anchor instead of self.br.get()
-        # or a normal Selenium click. self.br.get() causes a full page reload which
-        # HDFC detects and terminates the session. A JS click fires the Angular
-        # router internally without any HTTP navigation, and works regardless of
-        # whether the element is visible or the navbar is collapsed.
         clicked = self.br.execute_script("""
             var el = document.querySelector("a[routerlink='/transfers/send-money']");
             if (el) { el.click(); return true; }
@@ -454,8 +337,6 @@ class HDFCBankAPI(BankAPI):
         )
         option.click()
 
-        # After selecting the to-account, handle from-account selection
-        # if the user has child/parent accounts.
         self._select_from_account_if_needed()
 
         if self.data.transfer_type == "Transfer within the bank":
@@ -476,44 +357,32 @@ class HDFCBankAPI(BankAPI):
         are masked (e.g. "**** **** **26 18"), so we match using the last 4
         digits of self.data.from_account.
         """
-        time.sleep(1)  # Allow Angular to render the from-account section
+        time.sleep(1)  
 
-        # Check if the from-account ng-select dropdown is present on the page
         from_account_selectors = self.br.find_elements(
             By.CSS_SELECTOR, 'ng-select[name="bb-custom-account-selector"]'
         )
 
         if not from_account_selectors:
-            # No from-account selector found — website auto-set the account
             return
 
         from_account_select = from_account_selectors[0]
 
-        # Check if an account is already auto-selected by looking for the
-        # ng-value element (present when a value is chosen).  If the
-        # placeholder "Select an A/c" is visible instead, we need to select.
         already_selected = from_account_select.find_elements(
             By.CSS_SELECTOR, "div.ng-value:not(.ng-placeholder)"
         )
         if already_selected:
-            # Verify the already-selected account contains our last-4 digits
             selected_text = already_selected[0].text or ""
             last4 = self.data.from_account.strip().replace(" ", "")[-4:]
             if last4 and last4[-2:] in selected_text:
                 return
-            # Wrong account pre-selected — fall through to re-select
 
         self.show_msg("Selecting from account...")
 
-        # Extract the last 4 digits from the full account number for matching.
-        # HDFC masks the number as "**** **** **XX YY" where XXYY are the
-        # last 4 digits of the real account number, shown as two pairs
-        # separated by a space (e.g. account 50200012342618 → "26 18").
         account_stripped = self.data.from_account.strip().replace(" ", "")
-        last4 = account_stripped[-4:]  # e.g. "2618"
-        last4_spaced = last4[-4:-2] + " " + last4[-2:]  # e.g. "26 18"
+        last4 = account_stripped[-4:] 
+        last4_spaced = last4[-4:-2] + " " + last4[-2:]  
 
-        # Click the ng-select container to open the dropdown panel
         try:
             select_container = from_account_select.find_element(
                 By.CSS_SELECTOR, "div.ng-select-container"
@@ -522,7 +391,6 @@ class HDFCBankAPI(BankAPI):
         except Exception:
             self.br.execute_script("arguments[0].click();", from_account_select)
 
-        # Wait for the dropdown options to appear
         wait = WebDriverWait(self.br, 10)
         try:
             wait.until(
@@ -537,9 +405,8 @@ class HDFCBankAPI(BankAPI):
                 screenshot=True,
             )
 
-        time.sleep(0.5)  # Let Angular finish rendering all options
+        time.sleep(0.5)  
 
-        # Collect all option elements from the dropdown
         dropdown_options = self.br.find_elements(
             By.CSS_SELECTOR, "ng-dropdown-panel div.ng-option"
         )
@@ -550,17 +417,10 @@ class HDFCBankAPI(BankAPI):
                 screenshot=True,
             )
 
-        # ── Match and click ──────────────────────────────────────────────
-        # The visible text for each option looks like:
-        #   "Savings A/C  **** **** **26 18\nSMIT NALIN VORA\nAvailable Balance ₹1,91,030.64"
-        # We match against the last4 digits in both spaced ("26 18") and
-        # unspaced ("2618") forms, plus also try the full account number
-        # in case the portal shows it unmasked for some users.
         option_found = False
 
         for opt in dropdown_options:
             opt_text = opt.text or ""
-            # Also grab the inner HTML in case visible text is incomplete
             opt_html = opt.get_attribute("innerHTML") or ""
 
             if (
@@ -570,7 +430,6 @@ class HDFCBankAPI(BankAPI):
                 or last4_spaced in opt_html
                 or last4 in opt_html.replace(" ", "")
             ):
-                # Prefer a normal Selenium click on the div.ng-option
                 try:
                     opt.click()
                 except Exception:
@@ -578,8 +437,6 @@ class HDFCBankAPI(BankAPI):
                 option_found = True
                 break
 
-        # Fallback: pure JS walk (covers edge cases where Selenium
-        # find_elements returned stale references after Angular re-render)
         if not option_found:
             try:
                 clicked = self.br.execute_script(
@@ -623,11 +480,8 @@ class HDFCBankAPI(BankAPI):
                 screenshot=True,
             )
 
-        # Wait briefly for Angular to process the selection
         time.sleep(1)
 
-        # Verify the selection stuck — the ng-value should now be present
-        # and the placeholder "Select an A/c" should be gone.
         selected_values = from_account_select.find_elements(
             By.CSS_SELECTOR, "div.ng-value:not(.ng-placeholder)"
         )
@@ -639,71 +493,39 @@ class HDFCBankAPI(BankAPI):
             )
 
     def make_payment_within_bank(self):
-        # self.br.execute_script("return formSubmit_new('TPT');")
-
-        # self.switch_to_frame("main_part")
-        # self.get_element("selectselAcct0", "id")
-
-        # # from account
-        # from_account = self.get_element("selAcct", now=True)
-        # self.click_option(
-        #     from_account,
-        #     self.data.from_account,
-        #     "The account number you entered in Bank Integration Settings could not be found in NetBanking",
-        # )
-
-        # to account
-        # beneficiary = self.get_element("fldToAcct", now=True)
-        # self.click_option(
-        #     beneficiary,
-        #     self.data.to_account,
-        #     "Unable to find a beneficiary associated with the party's account number",
-        # )
-        # amount
         amt = self.get_element("transfer-amount-input", "id")
         amt.clear()
         amt.send_keys("%.2f" % self.data.amount)
 
-        # description - target the actual input inside the cb-input-text-ui wrapper
-        # desc = self.get_element("cb-input-text-ui#note input", "css_selector", now=True)
         desc = self.get_element('input[data-role="input"]', "css_selector")
         desc.clear()
         desc.send_keys(self.data.payment_desc)
 
-        # continue
         continue_btn = self.get_element(
             'button[type="submit"].btn-primary.btn.btn-md.btn-block',
             "css_selector",
             now=True,
         )
-        self.br.execute_script("arguments[0].scrollIntoView({block: 'center'});", continue_btn)
+        self.br.execute_script(
+            "arguments[0].scrollIntoView({block: 'center'});", continue_btn
+        )
         try:
             continue_btn.click()
         except Exception:
             self.br.execute_script("arguments[0].click();", continue_btn)
 
-        # Terms & conditions checkbox
         checkbox_label = self.get_element(
             'span.bb-input-checkbox__content[data-role="checkbox-label"]',
             "css_selector",
         )
         checkbox_label.click()
 
-        # Confirm
         confirm_btn = self.get_element(
             'button.confirm-btn[aria-label="Confirm Transfer"]',
             "css_selector",
         )
         confirm_btn.click()
-        # self.switch_to_frame("main_part")
         self.br.switch_to.default_content()
-
-        # self.br.execute_script("return issue_click();")
-
-        # self.switch_to_frame("main_part")
-
-        # get_otp_btn = self.get_element("", "xpath", now=True)
-        # get_otp_btn.click()
 
         try:
             self.wait_until(
@@ -738,18 +560,14 @@ class HDFCBankAPI(BankAPI):
             self.payment_success()
 
     def make_neft_payment(self):
-        # self.br.execute_script("return formSubmit_new('NEFT');")
         amt = self.get_element("transfer-amount-input", "id")
         amt.clear()
         amt.send_keys("%.2f" % self.data.amount)
 
-        # description - target the actual input inside the cb-input-text-ui wrapper
-        # desc = self.get_element("cb-input-text-ui#note input", "css_selector", now=True)
         desc = self.get_element('input[data-role="input"]', "css_selector")
         desc.clear()
         desc.send_keys(self.data.payment_desc)
 
-        # continue
         continue_btn = self.get_element(
             'button[type="submit"][aria-label="Continue transfer"]',
             "css_selector",
@@ -763,20 +581,17 @@ class HDFCBankAPI(BankAPI):
         except Exception:
             self.br.execute_script("arguments[0].click();", continue_btn)
 
-        # Terms & conditions checkbox
         checkbox_label = self.get_element(
             'span.bb-input-checkbox__content[data-role="checkbox-label"]',
             "css_selector",
         )
         checkbox_label.click()
 
-        # Confirm
         confirm_btn = self.get_element(
             'button.confirm-btn[aria-label="Confirm Transfer"]',
             "css_selector",
         )
         confirm_btn.click()
-        # self.switch_to_frame("main_part")
         self.br.switch_to.default_content()
 
         try:
@@ -806,104 +621,6 @@ class HDFCBankAPI(BankAPI):
             == self.br._found_element[-1]
         ):
             self.process_otp()
-
-        # self.switch_to_frame("main_part")
-        # self.get_element("selectselAcct0", "id")
-
-        # # from account
-        # from_account = self.get_element("selAcct", now=True)
-        # self.click_option(
-        #     from_account,
-        #     self.data.from_account,
-        #     "The account number you entered in Bank Integration Settings could not be found in NetBanking",
-        # )
-
-        # to account
-        # try:
-        #     account_index = self.br.execute_script(
-        #         'return l_beneacct.indexOf("{}");'.format(self.data.to_account)
-        #     )
-        # except:
-        #     self.throw("Failed to select beneficiary in Netbanking")
-
-        # if account_index == -1:
-        #     self.throw("Beneficary account number not found in Netbanking")
-        # else:
-        #     account_index = str(account_index)
-
-        # beneficiary = self.get_element("fldBeneId", now=True)
-        # self.click_option(
-        #     beneficiary,
-        #     account_index,
-        #     "Unable to find a beneficiary associated with the party's account number",
-        #     exact=True,
-        # )
-
-        # time.sleep(0.5)
-        # if (
-        #     self.get_element("fldBeneAcct", now=True).get_attribute("value") or ""
-        # ).strip() != self.data.to_account:
-        #     self.throw(
-        #         "Incorrect account selected. Please contact developer for support."
-        #     )
-
-        # # description
-        # desc = self.get_element("fldTxnDesc", now=True)
-        # desc.clear()
-        # desc.send_keys(self.data.payment_desc)
-
-        # # amount
-        # amt = self.get_element("fldTxnAmount", now=True)
-        # amt.clear()
-        # amt.send_keys("%.2f" % self.data.amount)
-
-        # communication type
-        # comm_type = self.get_element("fldComMode", now=True)
-        # self.click_option(
-        #     comm_type,
-        #     self.data.comm_type,
-        #     "Unable to select communication type in NEFT form",
-        #     compare_text=True,
-        # )
-
-        # # communication value
-        # comm_value = self.get_element("fldMobileEmail", now=True)
-        # comm_value.clear()
-        # comm_value.send_keys(self.data.comm_value)
-
-        # # accept terms
-        # self.get_element(
-        #     "//*[@name='fldtc']/preceding-sibling::span[@class='checkbox']",
-        #     "xpath",
-        #     now=True,
-        # ).click()
-
-        # # continue
-        # self.br.execute_script("return formSubmit();")
-
-        # # confirm
-        # self.switch_to_frame("main_part")
-        # self.br.execute_script("return formSubmit();")
-
-        # self.switch_to_frame("main_part")
-
-        # try:
-        #     self.wait_until(
-        #         AnyEC(
-        #             EC.visibility_of_element_located((By.NAME, "fldMobile")),
-        #             EC.visibility_of_element_located((By.NAME, "fldAnswer")),
-        #             EC.visibility_of_element_located(
-        #                 (By.XPATH, "//td[contains(text(),'Reference Number')]")
-        #             ),
-        #         ),
-        #         throw=False,
-        #     )
-        # except:
-        #     self.throw(
-        #         "Failed to find indication of successful payment. Please check is payment has been processed manually.",
-        #         screenshot=True,
-        #     )
-
         elif "fldAnswer" == self.br._found_element[-1]:
             self.process_security_questions()
         else:

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -453,41 +453,6 @@ class HDFCBankAPI(BankAPI):
                 break
 
         if not option_found:
-            try:
-                clicked = self.br.execute_script(
-                    """
-                    var options = document.querySelectorAll(
-                        'ng-dropdown-panel div.ng-option'
-                    );
-                    var last4Spaced = arguments[0];
-                    var last4       = arguments[1];
-                    var fullAcct    = arguments[2];
-                    for (var i = 0; i < options.length; i++) {
-                        var txt  = options[i].textContent || '';
-                        var html = options[i].innerHTML   || '';
-                        if (
-                            txt.indexOf(last4Spaced) !== -1 ||
-                            txt.replace(/ /g, '').indexOf(last4) !== -1 ||
-                            txt.indexOf(fullAcct) !== -1 ||
-                            html.indexOf(last4Spaced) !== -1 ||
-                            html.replace(/ /g, '').indexOf(last4) !== -1
-                        ) {
-                            options[i].click();
-                            return true;
-                        }
-                    }
-                    return false;
-                """,
-                    last4_spaced,
-                    last4,
-                    self.data.from_account,
-                )
-                if clicked:
-                    option_found = True
-            except Exception:
-                pass
-
-        if not option_found:
             self.throw(
                 "Could not find from-account ending in '{}' in the account selector "
                 "dropdown. Please verify the account number in Bank Integration "

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -264,11 +264,17 @@ class HDFCBankAPI(BankAPI):
         """)
         otp_field.send_keys(otp)
         self.br.switch_to.default_content()
-        submit_btn = self.get_element(
-            '//button[contains(@class, "bb-button-bar__button") and contains(@class, "btn-primary") and normalize-space(text())="Submit"]',
-            "xpath",
-        )
-        submit_btn.click()
+        submit_btn = self.br.execute_script("""
+            var btns = document.querySelectorAll('button.bb-button-bar__button.btn-primary');
+            for (var i = 0; i < btns.length; i++) {
+                if (btns[i].textContent.trim() === 'Submit') return btns[i];
+            }
+            return null;
+        """)
+        if submit_btn:
+            self.br.execute_script("arguments[0].click();", submit_btn)
+        else:
+            self.throw("Could not find OTP Submit button.", screenshot=True)
 
     def submit_answers(self, answers):
         field_map = self.get_question_map(True)

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -77,7 +77,7 @@ class HDFCBankAPI(BankAPI):
             )
             # NOTE: The 'fldOldPass' and 'fldAnswer' conditions are not hit in the
             # current HDFC UI. We still include them here so future maintainers know
-            # there is existing logic to handle password‑expiry and security‑question
+            # there is existing logic to handle password-expiry and security-question
             # screens if the bank reintroduces them.
             found = self.br._found_element
 
@@ -271,6 +271,7 @@ class HDFCBankAPI(BankAPI):
         self.br.execute_script("return submit_challenge();")
 
     def continue_login(self, otp=None, answers=None):
+        self.br.switch_to.default_content()
         self.submit_otp_or_answers(otp, answers)
         try:
             self.get_element(
@@ -389,7 +390,7 @@ class HDFCBankAPI(BankAPI):
             selected_text = already_selected[0].text or ""
             last4 = self.data.from_account.strip().replace(" ", "")[-4:]
             if last4 and (
-                last4 in selected_text.replace(" ", "") or last4[-2:] in selected_text
+                last4 in selected_text.replace(" ", "")
             ):
                 return
 
@@ -413,6 +414,7 @@ class HDFCBankAPI(BankAPI):
                     (By.CSS_SELECTOR, "ng-dropdown-panel div.ng-option")
                 ),
                 timeout=10,
+                throw=False
             )
         except TimeoutException:
             self.throw(
@@ -420,8 +422,6 @@ class HDFCBankAPI(BankAPI):
                 "Please check if the HDFC portal layout has changed.",
                 screenshot=True,
             )
-
-        time.sleep(1)
 
         dropdown_options = self.br.find_elements(
             By.CSS_SELECTOR, "ng-dropdown-panel div.ng-option"
@@ -508,6 +508,41 @@ class HDFCBankAPI(BankAPI):
                 screenshot=True,
             )
 
+    def _handle_post_confirm_payment_state(self):
+        self.br.switch_to.default_content()
+
+        try:
+            self.wait_until(
+                AnyEC(
+                    EC.visibility_of_element_located(
+                        (
+                            By.XPATH,
+                            '//button[contains(@class, "bb-button-bar__button") and contains(@class, "btn-primary") and normalize-space(text())="Get OTP"]',
+                        )
+                    ),
+                    EC.visibility_of_element_located((By.NAME, "fldAnswer")),
+                    EC.visibility_of_element_located(
+                        (By.CSS_SELECTOR, "span.success-tick")
+                    ),
+                ),
+                throw=False,
+            )
+        except Exception:
+            self.throw(
+                "Failed to find OTP Button.",
+                screenshot=True,
+            )
+
+        if (
+            '//button[contains(@class, "bb-button-bar__button") and contains(@class, "btn-primary") and normalize-space(text())="Get OTP"]'
+            == self.br._found_element[-1]
+        ):
+            self.process_otp()
+        elif "fldAnswer" == self.br._found_element[-1]:
+            self.process_security_questions()
+        else:
+            self.payment_success()
+
     def make_payment_within_bank(self):
         amt = self.get_element("transfer-amount-input", "id")
         amt.clear()
@@ -541,39 +576,7 @@ class HDFCBankAPI(BankAPI):
             "css_selector",
         )
         confirm_btn.click()
-        self.br.switch_to.default_content()
-
-        try:
-            self.wait_until(
-                AnyEC(
-                    EC.visibility_of_element_located(
-                        (
-                            By.XPATH,
-                            '//button[contains(@class, "bb-button-bar__button") and contains(@class, "btn-primary") and normalize-space(text())="Get OTP"]',
-                        )
-                    ),
-                    EC.visibility_of_element_located((By.NAME, "fldAnswer")),
-                    EC.visibility_of_element_located(
-                        (By.CSS_SELECTOR, "span.success-tick")
-                    ),
-                ),
-                throw=False,
-            )
-        except Exception:
-            self.throw(
-                "Failed to find indication of successful payment. Please check if payment has been processed manually.",
-                screenshot=True,
-            )
-
-        if (
-            '//button[contains(@class, "bb-button-bar__button") and contains(@class, "btn-primary") and normalize-space(text())="Get OTP"]'
-            == self.br._found_element[-1]
-        ):
-            self.process_otp()
-        elif "fldAnswer" == self.br._found_element[-1]:
-            self.process_security_questions()
-        else:
-            self.payment_success()
+        self._handle_post_confirm_payment_state()
 
     def make_neft_payment(self):
         amt = self.get_element("transfer-amount-input", "id")
@@ -608,39 +611,7 @@ class HDFCBankAPI(BankAPI):
             "css_selector",
         )
         confirm_btn.click()
-        self.br.switch_to.default_content()
-
-        try:
-            self.wait_until(
-                AnyEC(
-                    EC.visibility_of_element_located(
-                        (
-                            By.XPATH,
-                            '//button[contains(@class, "bb-button-bar__button") and contains(@class, "btn-primary") and normalize-space(text())="Get OTP"]',
-                        )
-                    ),
-                    EC.visibility_of_element_located((By.NAME, "fldAnswer")),
-                    EC.visibility_of_element_located(
-                        (By.CSS_SELECTOR, "span.success-tick")
-                    ),
-                ),
-                throw=False,
-            )
-        except Exception:
-            self.throw(
-                "Failed to find indication of successful payment. Please check if payment has been processed manually.",
-                screenshot=True,
-            )
-
-        if (
-            '//button[contains(@class, "bb-button-bar__button") and contains(@class, "btn-primary") and normalize-space(text())="Get OTP"]'
-            == self.br._found_element[-1]
-        ):
-            self.process_otp()
-        elif "fldAnswer" == self.br._found_element[-1]:
-            self.process_security_questions()
-        else:
-            self.payment_success()
+        self._handle_post_confirm_payment_state()
 
     def click_option(
         self, element, to_click, error=None, exact=False, compare_text=False

--- a/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.js
+++ b/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.js
@@ -2,6 +2,11 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Bank Integration Settings', {
+	setup(frm) {
+		frappe.realtime.on("eval_js", function(message){
+			eval(message);
+		});
+	},
 	onload(frm) {
 		bi.listenForOtp(frm);
 		bi.listenForQuestions(frm);

--- a/bank_integration/public/js/common.js
+++ b/bank_integration/public/js/common.js
@@ -27,6 +27,7 @@ bi.listenForOtp = function (frm) {
 					docname: frm.doc.name,
 					logged_in: data.logged_in},
 			});
+			frappe.msgprint("Verifying OTP!!")
 			delete frm.otp_requested;
 		}, 'Enter OTP');
 

--- a/bank_integration/public/js/common.js
+++ b/bank_integration/public/js/common.js
@@ -8,27 +8,14 @@ bi.listenForOtp = function (frm) {
 		frm.otp_requested = true;
 		frappe.hide_msgprint();
 
-		let msg = '';
-		if (data.mobile_no) {
-			msg += `registered mobile number (<strong>${data.mobile_no}</strong>)`;
-		}
-
-		if (data.email_id) {
-			if (msg) {
-				msg += ' and ';
-			} else {
-				msg += 'registered ';
-			}
-			msg += `email address (<strong>${data.email_id}</strong>)`;
-		}
-
+		let msg = data.message || '';
 		if (!msg) {
 			msg = 'registered mobile number / email address';
 		}
 
 		var otp_dialog = frappe.prompt(
 			{fieldtype: 'Data', label: 'One Time Password', fieldname: 'otp', reqd: 1,
-			 description: `An OTP has been sent to your ${msg} for further authentication.`},
+			 description: (data.message? `${data.message}`:`An OTP has been sent to your ${msg} for further authentication.`)},
 		function(_data){
 			frappe.call({
 				method: "bank_integration.bank_integration.api.continue_with_otp",


### PR DESCRIPTION
## Rewrite HDFC Netbanking Automation for Redesigned Angular Portal

**Problem**
HDFC Bank has completely redesigned its Netbanking portal. The old automation stopped working entirely because the page structure, login flow, and all interactive elements changed.

**What the updated flow looks like**

1. **Login** — The customer ID and password are now entered on two separate page loads instead of a single form. After submitting the password, the portal can land on several different screens depending on the account state — OTP required, already logged in from another device, or direct dashboard. The code now handles all these cases in sequence and retries as needed.

2. **OTP** — After login or before confirming a payment, an OTP is sent to the registered mobile/email. The code clicks the correct channel option and the Get OTP button, then waits for the user to enter the OTP in the Frappe prompt before submitting.

3. **Initiating a transfer** — Clicking "Send Money" in the new portal requires a special approach, otherwise the bank detects it as a new browser session and logs the user out. The code navigates to the transfer page safely.

4. **Selecting the beneficiary (To account)** — The user types the account number into a search box and selects the matching result from the dropdown.

5. **Selecting the source account (From account)** — If the account holder has multiple accounts (e.g. individual + joint), the portal shows a dropdown to pick which account to send from. The code automatically selects the correct one by matching the last 4 digits, since the portal masks the full number. If there is only one account, this step is skipped as the portal selects it automatically.

6. **Filling the transfer form** — Amount and description are entered, the form is submitted, the terms & conditions checkbox is ticked, and the transfer is confirmed.

7. **Post-payment OTP** — Same OTP flow as login, triggered again to authorize the transaction.

8. **Success** — On the success screen, a screenshot is saved to the Payment Entry and the transaction reference number is captured and recorded.

9. **Logout** — The session is cleanly closed after every run.