### PR TITLE
feat: attach payment receipt PDF instead of screenshot on successful payment

### DIFF
--- a/bank_integration/bank_integration/api/bank_api.py
+++ b/bank_integration/bank_integration/api/bank_api.py
@@ -2,6 +2,11 @@
 # Copyright (c) 2018, Resilient Tech and contributors
 # For license information, please see license.txt
 
+import time
+import tempfile
+import os
+import glob
+
 import frappe
 import bank_integration
 from frappe.utils.file_manager import save_file
@@ -64,7 +69,19 @@ class BankAPI:
 
         if not isinstance(RemoteConnection._timeout, (int, float)):
             RemoteConnection.set_timeout(90)
+
+        self.download_dir = tempfile.mkdtemp(prefix="bank_dl_")
+
         self.br = webdriver.Chrome(options=self.get_options())
+
+        # Enable downloads for headless Chrome
+        self.br.execute_cdp_cmd(
+            "Page.setDownloadBehavior",
+            {
+                "behavior": "allow",
+                "downloadPath": self.download_dir,
+            },
+        )
 
     def get_options(self):
         options = Options()
@@ -75,6 +92,16 @@ class BankAPI:
             "AppleWebKit/537.36 (KHTML, like Gecko) "
             "Chrome/121.0.0.0 Safari/537.36"
         )
+
+        if self.download_dir and os.path.isdir(self.download_dir):
+            options.add_experimental_option(
+                "prefs",
+                {
+                    "download.default_directory": self.download_dir,
+                    "download.prompt_for_download": False,
+                    "plugins.always_open_pdf_externally": True,
+                },
+            )
 
         if not frappe.conf.developer_mode:
             options.add_argument("--headless=new")
@@ -115,10 +142,11 @@ class BankAPI:
 
         resume_info = frappe._dict(cached["resume_info"])
 
+        self.download_dir = cached.get("download_dir") or ""
+
         self.br = webdriver.Remote(
             command_executor=resume_info.executor_url, options=self.get_options()
         )
-
         self.br.close()
         self.br.session_id = resume_info.session_id
 
@@ -195,7 +223,10 @@ class BankAPI:
         if not self.is_bulk_payments:
             frappe.cache().set_value(
                 self.cache_key,
-                {"resume_info": self.get_resume_info(), "data": self.data},
+                {"resume_info": self.get_resume_info(),
+                "data": self.data,
+                "download_dir": getattr(self, "download_dir", None),
+                },
                 user=frappe.session.user,
             )
         else:
@@ -207,6 +238,7 @@ class BankAPI:
                     "bulk_data": self.bulk_payments,
                     "is_bulk_payments": self.is_bulk_payments,
                     "remove_payment":self.remove_payment,
+                    "download_dir": getattr(self, "download_dir", None),
                 },
                 user=frappe.session.user,
             )
@@ -217,6 +249,58 @@ class BankAPI:
 
         if hasattr(bank_integration, self.cache_key):
             delattr(bank_integration, self.cache_key)
+
+    def wait_for_download(self, expected_filename=None, timeout=30):
+        """Wait for a file to finish downloading in self.download_dir.
+        Returns (filename, file_content_bytes) or (None, None) on timeout.
+        Ignores Chrome's partial .crdownload files.
+        """
+
+        if not getattr(self, "download_dir", None) or not os.path.isdir(
+            self.download_dir
+        ):
+            return None, None
+
+        for _ in range(timeout * 2):
+            files = glob.glob(os.path.join(self.download_dir, "*"))
+            done = [f for f in files if not f.endswith(".crdownload")]
+            if expected_filename:
+                done = [f for f in done if os.path.basename(f) == expected_filename]
+            if done:
+                filepath = done[0]
+                size1 = os.path.getsize(filepath)
+                time.sleep(0.2)
+                size2 = os.path.getsize(filepath)
+                if size1 == size2 and size1 > 0:
+                    with open(filepath, "rb") as f:
+                        content = f.read()
+                    return os.path.basename(filepath), content
+            time.sleep(0.5)
+        return None, None
+
+    def cleanup_download_dir(self, delete_dir=False):
+        """Clear the contents of the temp download directory.
+        If delete_dir is True, also remove the directory itself.
+        """
+        import os
+        import shutil
+
+        if hasattr(self, "download_dir") and self.download_dir:
+            try:
+                for entry in os.scandir(self.download_dir):
+                    if entry.is_dir(follow_symlinks=False):
+                        shutil.rmtree(entry.path)
+                    else:
+                        os.remove(entry.path)
+                if delete_dir:
+                    os.rmdir(self.download_dir)
+            except Exception:
+                frappe.log_error(
+                    frappe.get_traceback(),
+                    "Failed to cleanup payment receipt download directory: {}".format(
+                        self.download_dir
+                    ),
+                )
 
 
 class AnyEC:

--- a/bank_integration/bank_integration/api/bank_api.py
+++ b/bank_integration/bank_integration/api/bank_api.py
@@ -85,14 +85,16 @@ class BankAPI:
             "AppleWebKit/537.36 (KHTML, like Gecko) "
             "Chrome/121.0.0.0 Safari/537.36"
         )
-        options.add_experimental_option(
-            "prefs",
-            {
-                "download.default_directory": self.download_dir,
-                "download.prompt_for_download": False,
-                "plugins.always_open_pdf_externally": True,
-            },
-        )
+
+        if self.download_dir and os.path.isdir(self.download_dir):
+            options.add_experimental_option(
+                "prefs",
+                {
+                    "download.default_directory": self.download_dir,
+                    "download.prompt_for_download": False,
+                    "plugins.always_open_pdf_externally": True,
+                },
+            )
 
         if not frappe.conf.developer_mode:
             options.add_argument("--headless=new")
@@ -134,13 +136,14 @@ class BankAPI:
         self.br = webdriver.Remote(
             command_executor=resume_info.executor_url, options=self.get_options()
         )
-        self.br.execute_cdp_cmd(
-            "Page.setDownloadBehavior",
-            {
-                "behavior": "allow",
-                "downloadPath": self.download_dir,
-            },
-        )
+        if self.download_dir and os.path.isdir(self.download_dir):
+            self.br.execute_cdp_cmd(
+                "Page.setDownloadBehavior",
+                {
+                    "behavior": "allow",
+                    "downloadPath": self.download_dir,
+                },
+            )
         self.br.close()
         self.br.session_id = resume_info.session_id
 

--- a/bank_integration/bank_integration/api/bank_api.py
+++ b/bank_integration/bank_integration/api/bank_api.py
@@ -4,6 +4,8 @@
 
 import time
 import tempfile
+import os
+import glob
 
 import frappe
 import bank_integration
@@ -40,9 +42,6 @@ class BankAPI:
         self.uid = uid or frappe.utils.random_string(7)
         self.cache_key = "bank_" + self.uid
         self.data = data
-
-        # will be set in setup_browser()
-        self.download_dir = ""
 
         if getattr(self, "init"):
             self.init()
@@ -134,6 +133,13 @@ class BankAPI:
 
         self.br = webdriver.Remote(
             command_executor=resume_info.executor_url, options=self.get_options()
+        )
+        self.br.execute_cdp_cmd(
+            "Page.setDownloadBehavior",
+            {
+                "behavior": "allow",
+                "downloadPath": self.download_dir,
+            },
         )
         self.br.close()
         self.br.session_id = resume_info.session_id
@@ -227,7 +233,6 @@ class BankAPI:
         Returns (filename, file_content_bytes) or (None, None) on timeout.
         Ignores Chrome's partial .crdownload files.
         """
-        import os, glob
 
         if not getattr(self, "download_dir", None) or not os.path.isdir(
             self.download_dir
@@ -251,13 +256,22 @@ class BankAPI:
             time.sleep(0.5)
         return None, None
 
-    def cleanup_download_dir(self):
-        """Remove the temp download directory and its contents."""
+    def cleanup_download_dir(self, delete_dir=False):
+        """Clear the contents of the temp download directory.
+        If delete_dir is True, also remove the directory itself.
+        """
+        import os
         import shutil
 
         if hasattr(self, "download_dir") and self.download_dir:
             try:
-                shutil.rmtree(self.download_dir)
+                for entry in os.scandir(self.download_dir):
+                    if entry.is_dir(follow_symlinks=False):
+                        shutil.rmtree(entry.path)
+                    else:
+                        os.remove(entry.path)
+                if delete_dir:
+                    os.rmdir(self.download_dir)
             except Exception:
                 frappe.log_error(
                     frappe.get_traceback(),

--- a/bank_integration/bank_integration/api/bank_api.py
+++ b/bank_integration/bank_integration/api/bank_api.py
@@ -231,7 +231,7 @@ class BankAPI:
         ):
             return None, None
 
-        for _ in range(timeout * 2):  
+        for _ in range(timeout * 2):
             files = glob.glob(os.path.join(self.download_dir, "*"))
             done = [f for f in files if not f.endswith(".crdownload")]
             if expected_filename:
@@ -252,7 +252,12 @@ class BankAPI:
             try:
                 shutil.rmtree(self.download_dir, ignore_errors=True)
             except Exception:
-                pass
+                frappe.log_error(
+                    frappe.get_traceback(),
+                    "Failed to cleanup payment receipt download directory: {}".format(
+                        self.download_dir
+                    ),
+                )
 
 
 class AnyEC:

--- a/bank_integration/bank_integration/api/bank_api.py
+++ b/bank_integration/bank_integration/api/bank_api.py
@@ -250,7 +250,7 @@ class BankAPI:
 
         if hasattr(self, "download_dir") and self.download_dir:
             try:
-                shutil.rmtree(self.download_dir, ignore_errors=True)
+                shutil.rmtree(self.download_dir)
             except Exception:
                 frappe.log_error(
                     frappe.get_traceback(),

--- a/bank_integration/bank_integration/api/bank_api.py
+++ b/bank_integration/bank_integration/api/bank_api.py
@@ -147,14 +147,6 @@ class BankAPI:
         self.br = webdriver.Remote(
             command_executor=resume_info.executor_url, options=self.get_options()
         )
-        if self.download_dir and os.path.isdir(self.download_dir):
-            self.br.execute_cdp_cmd(
-                "Page.setDownloadBehavior",
-                {
-                    "behavior": "allow",
-                    "downloadPath": self.download_dir,
-                },
-            )
         self.br.close()
         self.br.session_id = resume_info.session_id
 

--- a/bank_integration/bank_integration/api/bank_api.py
+++ b/bank_integration/bank_integration/api/bank_api.py
@@ -2,6 +2,9 @@
 # Copyright (c) 2018, Resilient Tech and contributors
 # For license information, please see license.txt
 
+import time
+import tempfile
+
 import frappe
 import bank_integration
 from frappe.utils.file_manager import save_file
@@ -37,7 +40,6 @@ class BankAPI:
         self.uid = uid or frappe.utils.random_string(7)
         self.cache_key = "bank_" + self.uid
         self.data = data
-        
 
         if getattr(self, "init"):
             self.init()
@@ -55,9 +57,22 @@ class BankAPI:
 
     def setup_browser(self):
         from selenium.webdriver.remote.remote_connection import RemoteConnection
-        if not isinstance(RemoteConnection._timeout, (int, float)) :
+
+        if not isinstance(RemoteConnection._timeout, (int, float)):
             RemoteConnection.set_timeout(90)
+
+        self.download_dir = tempfile.mkdtemp(prefix="bank_dl_")
+
         self.br = webdriver.Chrome(options=self.get_options())
+
+        # Enable downloads for headless Chrome
+        self.br.execute_cdp_cmd(
+            "Page.setDownloadBehavior",
+            {
+                "behavior": "allow",
+                "downloadPath": self.download_dir,
+            },
+        )
 
     def get_options(self):
         options = Options()
@@ -67,6 +82,14 @@ class BankAPI:
             "--user-agent=Mozilla/5.0 (X11; Linux x86_64) "
             "AppleWebKit/537.36 (KHTML, like Gecko) "
             "Chrome/121.0.0.0 Safari/537.36"
+        )
+        options.add_experimental_option(
+            "prefs",
+            {
+                "download.default_directory": self.download_dir,
+                "download.prompt_for_download": False,
+                "plugins.always_open_pdf_externally": True,
+            },
         )
 
         if not frappe.conf.developer_mode:
@@ -103,6 +126,8 @@ class BankAPI:
 
         self.data = frappe._dict(cached["data"] or {})
         resume_info = frappe._dict(cached["resume_info"])
+
+        self.download_dir = cached.get("download_dir") or ""
 
         self.br = webdriver.Remote(
             command_executor=resume_info.executor_url, options=self.get_options()
@@ -178,7 +203,11 @@ class BankAPI:
     def save_for_later(self):
         frappe.cache().set_value(
             self.cache_key,
-            {"resume_info": self.get_resume_info(), "data": self.data},
+            {
+                "resume_info": self.get_resume_info(),
+                "data": self.data,
+                "download_dir": getattr(self, "download_dir", None),
+            },
             user=frappe.session.user,
         )
 
@@ -189,6 +218,41 @@ class BankAPI:
 
         if hasattr(bank_integration, self.cache_key):
             delattr(bank_integration, self.cache_key)
+
+    def wait_for_download(self, expected_filename=None, timeout=30):
+        """Wait for a file to finish downloading in self.download_dir.
+        Returns (filename, file_content_bytes) or (None, None) on timeout.
+        Ignores Chrome's partial .crdownload files.
+        """
+        import os, glob
+
+        if not getattr(self, "download_dir", None) or not os.path.isdir(
+            self.download_dir
+        ):
+            return None, None
+
+        for _ in range(timeout * 2):  
+            files = glob.glob(os.path.join(self.download_dir, "*"))
+            done = [f for f in files if not f.endswith(".crdownload")]
+            if expected_filename:
+                done = [f for f in done if os.path.basename(f) == expected_filename]
+            if done:
+                filepath = done[0]
+                with open(filepath, "rb") as f:
+                    content = f.read()
+                return os.path.basename(filepath), content
+            time.sleep(0.5)
+        return None, None
+
+    def cleanup_download_dir(self):
+        """Remove the temp download directory and its contents."""
+        import shutil
+
+        if hasattr(self, "download_dir") and self.download_dir:
+            try:
+                shutil.rmtree(self.download_dir, ignore_errors=True)
+            except Exception:
+                pass
 
 
 class AnyEC:

--- a/bank_integration/bank_integration/api/bank_api.py
+++ b/bank_integration/bank_integration/api/bank_api.py
@@ -41,6 +41,9 @@ class BankAPI:
         self.cache_key = "bank_" + self.uid
         self.data = data
 
+        # will be set in setup_browser()
+        self.download_dir = ""
+
         if getattr(self, "init"):
             self.init()
 
@@ -238,9 +241,13 @@ class BankAPI:
                 done = [f for f in done if os.path.basename(f) == expected_filename]
             if done:
                 filepath = done[0]
-                with open(filepath, "rb") as f:
-                    content = f.read()
-                return os.path.basename(filepath), content
+                size1 = os.path.getsize(filepath)
+                time.sleep(0.2)
+                size2 = os.path.getsize(filepath)
+                if size1 == size2 and size1 > 0:
+                    with open(filepath, "rb") as f:
+                        content = f.read()
+                    return os.path.basename(filepath), content
             time.sleep(0.5)
         return None, None
 

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -384,6 +384,7 @@ class HDFCBankAPI(BankAPI):
                     "We were unable to complete the logout process on the bank website. Please manually log out from your online banking account to end the session safely."
                 )
         self.delete_cache()
+        self.cleanup_download_dir(delete_dir=True)
         self.br.quit()
 
     @set_correct_payment_data
@@ -719,13 +720,36 @@ class HDFCBankAPI(BankAPI):
         details_button = self.get_element("showHideBtn", "id")
         details_button.click()
 
-        save_file(
-            self.data.docname + " Online Payment Screenshot.png",
-            self.br.get_screenshot_as_png(),
-            "Payment Entry",
-            self.data.docname,
-            is_private=1,
-        )
+        pdf_saved = False
+        try:
+            self.cleanup_download_dir(delete_dir=False)
+            download_btn = self.br.find_element(
+                By.CSS_SELECTOR,
+                "button.down-btn.btn-link",
+            )
+            self.br.execute_script("arguments[0].click();", download_btn)
+            # make sure to clear the download directory before starting a new payment in bulk payments
+            filename, content = self.wait_for_download(expected_filename="transfer.pdf")
+            if filename and content:
+                save_file(
+                    self.data.docname + " Payment Receipt.pdf",
+                    content,
+                    "Payment Entry",
+                    self.data.docname,
+                    is_private=1,
+                )
+                pdf_saved = True
+        except Exception:
+            frappe.log_error(frappe.get_traceback(), "PDF receipt download failed; falling back to screenshot")
+
+        if not pdf_saved:
+            save_file(
+                self.data.docname + " Online Payment Screenshot.png",
+                self.br.get_screenshot_as_png(),
+                "Payment Entry",
+                self.data.docname,
+                is_private=1,
+            )
 
         ref_no = "-"
         if self.data.transfer_type == "Transfer within the bank":

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -339,6 +339,7 @@ class HDFCBankAPI(BankAPI):
                     "We were unable to complete the logout process on the bank website. Please manually log out from your online banking account to end the session safely."
                 )
         self.delete_cache()
+        self.cleanup_download_dir()
         self.br.quit()
 
     def make_payment(self):
@@ -639,13 +640,29 @@ class HDFCBankAPI(BankAPI):
         details_button = self.get_element("showHideBtn", "id")
         details_button.click()
 
-        save_file(
-            self.docname + " Online Payment Screenshot.png",
-            self.br.get_screenshot_as_png(),
-            self.doctype,
-            self.docname,
-            is_private=1,
-        )
+        try:
+            download_btn = self.br.find_element(
+                By.CSS_SELECTOR,
+                "button.down-btn.btn-link",
+            )
+            self.br.execute_script("arguments[0].click();", download_btn)
+            filename, content = self.wait_for_download(expected_filename="transfer.pdf")
+            if filename and content:
+                save_file(
+                    self.docname + " Payment Receipt.pdf",
+                    content,
+                    self.doctype,
+                    self.docname,
+                    is_private=1,
+                )
+        except Exception:
+            save_file(
+                self.docname + " Online Payment Screenshot.png",
+                self.br.get_screenshot_as_png(),
+                self.doctype,
+                self.docname,
+                is_private=1,
+            )
 
         ref_no = "-"
         if self.data.transfer_type == "Transfer within the bank":

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -648,6 +648,7 @@ class HDFCBankAPI(BankAPI):
                 "button.down-btn.btn-link",
             )
             self.br.execute_script("arguments[0].click();", download_btn)
+            # make sure to clear the download directory before starting a new payment in bulk payments
             filename, content = self.wait_for_download(expected_filename="transfer.pdf")
             if filename and content:
                 save_file(
@@ -659,7 +660,7 @@ class HDFCBankAPI(BankAPI):
                 )
                 pdf_saved = True
         except Exception:
-            pass
+            frappe.log_error(frappe.get_traceback(), "PDF receipt download failed; falling back to screenshot")
 
         if not pdf_saved:
             save_file(

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -641,6 +641,7 @@ class HDFCBankAPI(BankAPI):
         details_button = self.get_element("showHideBtn", "id")
         details_button.click()
 
+        pdf_saved = False
         try:
             download_btn = self.br.find_element(
                 By.CSS_SELECTOR,
@@ -656,7 +657,11 @@ class HDFCBankAPI(BankAPI):
                     self.docname,
                     is_private=1,
                 )
+                pdf_saved = True
         except Exception:
+            pass
+
+        if not pdf_saved:
             save_file(
                 self.docname + " Online Payment Screenshot.png",
                 self.br.get_screenshot_as_png(),

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -340,7 +340,7 @@ class HDFCBankAPI(BankAPI):
                     "We were unable to complete the logout process on the bank website. Please manually log out from your online banking account to end the session safely."
                 )
         self.delete_cache()
-        self.cleanup_download_dir()
+        self.cleanup_download_dir(delete_dir=True)
         self.br.quit()
 
     def make_payment(self):
@@ -643,6 +643,7 @@ class HDFCBankAPI(BankAPI):
 
         pdf_saved = False
         try:
+            self.cleanup_download_dir(delete_dir=False)
             download_btn = self.br.find_element(
                 By.CSS_SELECTOR,
                 "button.down-btn.btn-link",


### PR DESCRIPTION
Closes: https://github.com/resilient-tech/bank_integration/issues/21

## Problem
Previously, after a successful payment the system attached a **screenshot (.png)** of the browser as the receipt.

## Solution
The HDFC success page provides a **Download** button that generates an official **PDF receipt (`transfer.pdf`)**.  
This PR automates clicking that button, waits for the PDF to download, and attaches it to the document.

If the download fails for any reason, the system **falls back to attaching a screenshot**, preserving the previous behavior.

## Key Changes

### `bank_api.py`
- Creates a **temporary download folder** when the browser starts.
- Configures Chrome to **download files silently** and download PDFs instead of opening them in the viewer.
- Allows downloads in **headless Chrome**.
- Saves the download folder path in **Redis** between the login and OTP requests.
- Restores the path when the session resumes.
- Adds `wait_for_download()` to detect completed downloads.
- Adds `cleanup_download_dir()` to remove temp files after logout.

### `hdfc_bank_api.py`
- **payment_success()**
  - Clicks the **Download** button (`button.down-btn.btn-link`)
  - Waits for the PDF download
  - Attaches the PDF to the document
  - Falls back to a screenshot if the download fails

- **logout()**
  - Cleans up the temporary download folder before closing the browser.
