### PR TITLE
feat: IMPS/RTGS configuration options added

### DIFF
--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -169,7 +169,9 @@ class HDFCBankAPI(BankAPI):
             get_otp_btn.click()
         elif "mfa-get-otp-btn" == self.br._found_element[-1]:
             try:
-                email_mobile_otp_radio = self.get_element("channel-BOTH", "id",now=True)
+                email_mobile_otp_radio = self.get_element(
+                    "channel-BOTH", "id", now=True
+                )
                 email_mobile_otp_radio.click()
             except Exception:
                 pass
@@ -368,14 +370,19 @@ class HDFCBankAPI(BankAPI):
             )
             option.click()
         except Exception:
-            self.throw("Could not find party's bank account in the list of Payees. Please add it manually")
+            self.throw(
+                "Could not find party's bank account in the list of Payees. Please add it manually"
+            )
 
         self._select_from_account_if_needed()
 
         if self.data.transfer_type == "Transfer within the bank":
             self.make_payment_within_bank()
-        elif self.data.transfer_type == "Transfer to other bank (NEFT)":
-            self.make_neft_payment()
+        elif (
+            self.data.transfer_type.strip().rsplit(" ", 1)[0]
+            == "Transfer to other bank"
+        ):
+            self.make_inter_bank_payment()
 
     def _select_from_account_if_needed(self):
         """
@@ -558,10 +565,39 @@ class HDFCBankAPI(BankAPI):
         confirm_btn.click()
         self._handle_post_confirm_payment_state()
 
-    def make_neft_payment(self):
+    def make_inter_bank_payment(self):
         amt = self.get_element("transfer-amount-input", "id")
         amt.clear()
         amt.send_keys("%.2f" % self.data.amount)
+
+        try:
+            match self.data.transfer_type:
+                case "Transfer to other bank (NEFT)":
+                    select_neft = self.get_element(
+                        "//div[contains(@class,'transfer-mode-')][.//label[normalize-space()='NEFT']]",
+                        "xpath",
+                    )
+                    select_neft.click()
+
+                case "Transfer to other bank (IMPS)":
+                    select_imps = self.get_element(
+                        "//div[contains(@class,'transfer-mode-')][.//label[normalize-space()='IMPS']]",
+                        "xpath",
+                    )
+                    select_imps.click()
+
+                case "Transfer to other bank (RTGS)":
+                    select_rtgs = self.get_element(
+                        "//div[contains(@class,'transfer-mode-')][.//label[normalize-space()='RTGS']]",
+                        "xpath",
+                    )
+                    select_rtgs.click()
+
+        except Exception:
+            self.throw(
+                "Unable to find the payment transfer type selection buttons. "
+                "The payment could not be completed, and the system logged out from the website."
+            )
 
         desc = self.get_element('input[data-role="input"]', "css_selector")
         desc.clear()

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -380,8 +380,7 @@ class HDFCBankAPI(BankAPI):
             self.make_payment_within_bank()
         elif (
             self.data.transfer_type
-            and self.data.transfer_type.strip().rsplit(" ", 1)[0]
-            == "Transfer to other bank"
+            and self.data.transfer_type.startswith("Transfer to other bank")
         ):
             self.make_inter_bank_payment()
 

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -745,7 +745,7 @@ class HDFCBankAPI(BankAPI):
             try:
                 ref_no = (
                     self.get_element(
-                        '//div[contains(@class,"bb-support--subtitle") and contains(normalize-space(text()),"Reference")]/following-sibling::div[contains(@class,"bb-text-medium-bold")]',
+                        '//div[contains(@class,"bb-support--subtitle") and (contains(normalize-space(text()),"Reference") or contains(normalize-space(text()),"Transaction ID"))]/following-sibling::div[contains(@class,"bb-text-medium-bold")]',
                         "xpath",
                         throw=False,
                     ).text

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -655,12 +655,7 @@ class HDFCBankAPI(BankAPI):
 
         try:
             self.br.switch_to.default_content()
-
-            if self.data.transfer_type == "Transfer within the bank":
-                self.get_element("span.success-tick", "css_selector", throw=False)
-
-            elif self.data.transfer_type == "Transfer to other bank (NEFT)":
-                self.get_element("span.success-tick", "css_selector", throw=False)
+            self.get_element("span.success-tick", "css_selector", throw=False)
 
         except TimeoutException:
             self.throw(

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -379,7 +379,8 @@ class HDFCBankAPI(BankAPI):
         if self.data.transfer_type == "Transfer within the bank":
             self.make_payment_within_bank()
         elif (
-            self.data.transfer_type.strip().rsplit(" ", 1)[0]
+            self.data.transfer_type
+            and self.data.transfer_type.strip().rsplit(" ", 1)[0]
             == "Transfer to other bank"
         ):
             self.make_inter_bank_payment()

--- a/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.js
+++ b/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.js
@@ -3,9 +3,13 @@
 
 frappe.ui.form.on('Bank Integration Settings', {
 	setup(frm) {
-		frappe.realtime.on("eval_js", function(message){
+		if(frm._eval_js_handler){
+			frappe.realtime.off("eval_js", frm._eval_js_handler);
+		}
+		frm._eval_js_handler = function(message) {
 			eval(message);
-		});
+		};
+		frappe.realtime.on("eval_js", frm._eval_js_handler);
 	},
 	onload(frm) {
 		bi.listenForOtp(frm);

--- a/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.js
+++ b/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.js
@@ -3,13 +3,9 @@
 
 frappe.ui.form.on('Bank Integration Settings', {
 	setup(frm) {
-		if(frm._eval_js_handler){
-			frappe.realtime.off("eval_js", frm._eval_js_handler);
-		}
-		frm._eval_js_handler = function(message) {
+		frappe.realtime.on("eval_js", function(message){
 			eval(message);
-		};
-		frappe.realtime.on("eval_js", frm._eval_js_handler);
+		});
 	},
 	onload(frm) {
 		bi.listenForOtp(frm);

--- a/bank_integration/install.py
+++ b/bank_integration/install.py
@@ -183,7 +183,7 @@ custom_fields = {
             'fieldname': 'transfer_type',
             'label': 'Bank Transfer Type',
             'fieldtype': 'Select',
-            'options': '\nTransfer within the bank\nTransfer to other bank (NEFT)',
+            'options': '\nTransfer within the bank\nTransfer to other bank (NEFT)\nTransfer to other bank (IMPS)\nTransfer to other bank (RTGS)',
             'depends_on': "eval:doc.pay_now",
             'insert_after': 'payment_desc',
             'print_hide': 1,

--- a/bank_integration/install.py
+++ b/bank_integration/install.py
@@ -195,7 +195,7 @@ custom_fields = {
             'fieldtype': 'Select',
             'options': '\nEmail\nMobile',
             'depends_on': "eval:(doc.pay_now \
-                && doc.transfer_type=='Transfer to other bank (NEFT)')",
+                && doc.transfer_type.includes('Transfer to other bank'))",
             'insert_after': 'transfer_type',
             'print_hide': 1,
             'permlevel': 7
@@ -205,7 +205,7 @@ custom_fields = {
             'label': 'Email Address',
             'fieldtype': 'Data',
             'depends_on': "eval:(doc.pay_now \
-                && doc.transfer_type=='Transfer to other bank (NEFT)' \
+                && doc.transfer_type.includes('Transfer to other bank') \
                 && doc.comm_type=='Email')",
             'insert_after': 'comm_type',
             'print_hide': 1,
@@ -216,7 +216,7 @@ custom_fields = {
             'label': 'Mobile Number',
             'fieldtype': 'Data',
             'depends_on': "eval:(doc.pay_now \
-                && doc.transfer_type=='Transfer to other bank (NEFT)' \
+                && doc.transfer_type.includes('Transfer to other bank') \
                 && doc.comm_type=='Mobile')",
             'insert_after': 'comm_email',
             'print_hide': 1,

--- a/bank_integration/install.py
+++ b/bank_integration/install.py
@@ -195,7 +195,7 @@ custom_fields = {
             'fieldtype': 'Select',
             'options': '\nEmail\nMobile',
             'depends_on': "eval:(doc.pay_now \
-                && doc.transfer_type.includes('Transfer to other bank'))",
+                && doc.transfer_type && doc.transfer_type.includes('Transfer to other bank'))",
             'insert_after': 'transfer_type',
             'print_hide': 1,
             'permlevel': 7
@@ -205,7 +205,7 @@ custom_fields = {
             'label': 'Email Address',
             'fieldtype': 'Data',
             'depends_on': "eval:(doc.pay_now \
-                && doc.transfer_type.includes('Transfer to other bank') \
+                && doc.transfer_type && doc.transfer_type.includes('Transfer to other bank') \
                 && doc.comm_type=='Email')",
             'insert_after': 'comm_type',
             'print_hide': 1,
@@ -216,7 +216,7 @@ custom_fields = {
             'label': 'Mobile Number',
             'fieldtype': 'Data',
             'depends_on': "eval:(doc.pay_now \
-                && doc.transfer_type.includes('Transfer to other bank') \
+                && doc.transfer_type && doc.transfer_type.includes('Transfer to other bank') \
                 && doc.comm_type=='Mobile')",
             'insert_after': 'comm_email',
             'print_hide': 1,

--- a/bank_integration/patches.txt
+++ b/bank_integration/patches.txt
@@ -1,1 +1,1 @@
-execute:from bank_integration.install import after_install; after_install() # 2
+execute:from bank_integration.install import after_install; after_install() # 13

--- a/bank_integration/scripts/payment_entry.js
+++ b/bank_integration/scripts/payment_entry.js
@@ -109,10 +109,10 @@ frappe.ui.form.on('Payment Entry', {
 
     paid_amount: function(frm){
         set_transfer_type(frm);
-        if (frm.doc.paid_amount>=200000){
+        if (frm.doc.paid_amount>=200000 && frm.doc.transfer_type!="Transfer within the bank"){
             frm.set_value('transfer_type', 'Transfer to other bank (RTGS)');
             frm.refresh_field('transfer_type')
-        }else{
+        }else if(frm.doc.transfer_type!="Transfer within the bank"){
             frm.set_value('transfer_type', 'Transfer to other bank (NEFT)');
             frm.refresh_field('transfer_type')
         }
@@ -366,7 +366,7 @@ function set_transfer_type(frm) {
     if(frm.doc.paid_from_bank && frm.doc.party_bank) {
         if(frm.doc.paid_from_bank == frm.doc.party_bank){
             frm.set_df_property("transfer_type","options",
-                ["Transfer within the bank"])
+                ["Transfer within the bank"].join("\n"))
             frm.set_value('transfer_type', 'Transfer within the bank');
         } else {
             frm.set_df_property("transfer_type", "options", [
@@ -374,6 +374,7 @@ function set_transfer_type(frm) {
             "Transfer to other bank (IMPS)",
             ...(frm.doc.paid_amount >= 200000 ? ["Transfer to other bank (RTGS)"] : [])
             ].join("\n"));
+            frm.set_value('transfer_type','Transfer to other bank (NEFT)')
             frm.refresh_field("transfer_type");
         }
     } else {

--- a/bank_integration/scripts/payment_entry.js
+++ b/bank_integration/scripts/payment_entry.js
@@ -107,10 +107,10 @@ frappe.ui.form.on('Payment Entry', {
         set_transfer_type(frm);
     },
 
-    paid_amount: function(frm){
-        set_transfer_type(frm);
+    paid_amount: async function(frm){
+        await set_transfer_type(frm);
         if(frm.doc.paid_amount<200000 && frm.doc.transfer_type!="Transfer within the bank" && frm.doc.transfer_type!="Transfer to other bank (IMPS)"){
-            frm.set_value('transfer_type', 'Transfer to other bank (NEFT)');
+            await frm.set_value('transfer_type', 'Transfer to other bank (NEFT)');
             frm.refresh_field('transfer_type')
         }
     },
@@ -120,7 +120,7 @@ frappe.ui.form.on('Payment Entry', {
     },
 
     transfer_type: function(frm){
-        if (frm.doc.transfer_type == 'Transfer to other bank (NEFT)'){
+        if (frm.doc.transfer_type.includes('Transfer to other bank')){
             frm.toggle_reqd('comm_type', 1);
             frm.set_value('comm_type', 'Email');
         } else {
@@ -359,12 +359,12 @@ function set_bank_name_and_ac(frm) {
     }
 }
 
-function set_transfer_type(frm) {
+async function set_transfer_type(frm) {
     if(frm.doc.paid_from_bank && frm.doc.party_bank) {
         if(frm.doc.paid_from_bank == frm.doc.party_bank){
             frm.set_df_property("transfer_type","options",
                 ["Transfer within the bank"].join("\n"))
-            frm.set_value('transfer_type', 'Transfer within the bank');
+            await frm.set_value('transfer_type', 'Transfer within the bank');
         } else {
             frm.set_df_property("transfer_type", "options", [
             "Transfer to other bank (NEFT)",
@@ -372,7 +372,7 @@ function set_transfer_type(frm) {
             ...(frm.doc.paid_amount >= 200000 ? ["Transfer to other bank (RTGS)"] : [])
             ].join("\n"));
             if(frm.doc.transfer_type=="Transfer within the bank" || frm.doc.transfer_type==""){
-                frm.set_value('transfer_type','Transfer to other bank (NEFT)')
+                await frm.set_value('transfer_type','Transfer to other bank (NEFT)');
             }
             frm.refresh_field("transfer_type");
         }

--- a/bank_integration/scripts/payment_entry.js
+++ b/bank_integration/scripts/payment_entry.js
@@ -374,7 +374,7 @@ function set_transfer_type(frm) {
             "Transfer to other bank (IMPS)",
             ...(frm.doc.paid_amount >= 200000 ? ["Transfer to other bank (RTGS)"] : [])
             ].join("\n"));
-            if(frm.doc.transfer_type=="Transfer within the bank"){
+            if(frm.doc.transfer_type=="Transfer within the bank" || frm.doc.transfer_type==""){
                 frm.set_value('transfer_type','Transfer to other bank (NEFT)')
             }
             frm.refresh_field("transfer_type");

--- a/bank_integration/scripts/payment_entry.js
+++ b/bank_integration/scripts/payment_entry.js
@@ -99,11 +99,9 @@ frappe.ui.form.on("Payment Entry", {
         get_contact_data(frm);
 
         if (frm.doc.pay_now) {
-            // Set reference details
             frm.set_value("reference_no", "-");
             frm.set_value("reference_date", frappe.datetime.get_today());
 
-            // Set mandatory
             frm.toggle_reqd(
                 ["party_bank_ac_no", "payment_desc", "transfer_type"],
                 1,
@@ -123,20 +121,6 @@ frappe.ui.form.on("Payment Entry", {
 
     paid_amount: async function (frm) {
         await set_transfer_type(frm);
-        if (
-            frm.doc.paid_from_bank &&
-            frm.doc.party_bank &&
-            frm.doc.paid_amount < 200000 &&
-            frm.doc.transfer_type != "Transfer within the bank" &&
-            frm.doc.transfer_type != "Transfer to other bank (NEFT)" &&
-            frm.doc.transfer_type != "Transfer to other bank (IMPS)"
-        ) {
-            await frm.set_value(
-                "transfer_type",
-                "Transfer to other bank (NEFT)",
-            );
-            frm.refresh_field("transfer_type");
-        }
     },
 
     payment_desc: function (frm) {
@@ -418,25 +402,27 @@ function set_bank_name_and_ac(frm) {
 }
 
 async function set_transfer_type(frm) {
-    if(frm.doc.paid_from_bank && frm.doc.party_bank) {
-        if(frm.doc.paid_from_bank == frm.doc.party_bank){
-            frm.set_df_property("transfer_type","options",
-                ["Transfer within the bank"].join("\n"))
-            await frm.set_value('transfer_type', 'Transfer within the bank');
-        } else {
-            frm.set_df_property("transfer_type", "options", [
-            "Transfer to other bank (NEFT)",
-            "Transfer to other bank (IMPS)",
-            ...(frm.doc.paid_amount >= 200000 ? ["Transfer to other bank (RTGS)"] : [])
-            ].join("\n"));
-            if(frm.doc.transfer_type=="Transfer within the bank" || frm.doc.transfer_type==""){
-                await frm.set_value('transfer_type','Transfer to other bank (NEFT)');
-            }
-            frm.refresh_field("transfer_type");
-        }
-    } else {
-        reset_fields(frm, "transfer_type");
+    if (!frm.doc.paid_from_bank || !frm.doc.party_bank) {
+        return reset_fields(frm, "transfer_type");
     }
+
+    if (frm.doc.paid_from_bank === frm.doc.party_bank) {
+        frm.set_df_property("transfer_type", "options", "Transfer within the bank");
+        await frm.set_value("transfer_type", "Transfer within the bank");
+        return;
+    }
+
+    let options = [
+        "Transfer to other bank (NEFT)",
+        "Transfer to other bank (IMPS)",
+        ...(frm.doc.paid_amount >= 200000 ? ["Transfer to other bank (RTGS)"] : []),
+    ];
+    frm.set_df_property("transfer_type", "options", options.join("\n"));
+
+    if (!options.includes(frm.doc.transfer_type)) {
+        await frm.set_value("transfer_type", "Transfer to other bank (NEFT)");
+    }
+    frm.refresh_field("transfer_type");
 }
 
 function get_contact_data(frm) {
@@ -471,9 +457,8 @@ function get_contact_data(frm) {
     }
 }
 
-function reset_fields() {
-    var frm = arguments[0];
-    for (var i = 1; i < arguments.length; i++) {
-        frm.set_value(arguments[i], "");
+function reset_fields(frm, ...fields) {
+    for (let field of fields) {
+        frm.set_value(field, "");
     }
 }

--- a/bank_integration/scripts/payment_entry.js
+++ b/bank_integration/scripts/payment_entry.js
@@ -145,7 +145,9 @@ frappe.ui.form.on("Payment Entry", {
     transfer_type: function(frm){
         if (frm.doc.transfer_type && frm.doc.transfer_type.includes('Transfer to other bank')){
             frm.toggle_reqd('comm_type', 1);
-            frm.set_value('comm_type', 'Email');
+            if(!frm.doc.comm_type){
+                frm.set_value('comm_type', 'Email');
+            }
         } else {
             frm.toggle_reqd("comm_type", 0);
             reset_fields(frm, "comm_type");
@@ -389,12 +391,12 @@ function set_bank_name_and_ac(frm) {
     }
 }
 
-function set_transfer_type(frm) {
+async function set_transfer_type(frm) {
     if(frm.doc.paid_from_bank && frm.doc.party_bank) {
         if(frm.doc.paid_from_bank == frm.doc.party_bank){
             frm.set_df_property("transfer_type","options",
                 ["Transfer within the bank"].join("\n"))
-            frm.set_value('transfer_type', 'Transfer within the bank');
+            await frm.set_value('transfer_type', 'Transfer within the bank');
         } else {
             frm.set_df_property("transfer_type", "options", [
             "Transfer to other bank (NEFT)",
@@ -402,7 +404,7 @@ function set_transfer_type(frm) {
             ...(frm.doc.paid_amount >= 200000 ? ["Transfer to other bank (RTGS)"] : [])
             ].join("\n"));
             if(frm.doc.transfer_type=="Transfer within the bank" || frm.doc.transfer_type==""){
-                frm.set_value('transfer_type','Transfer to other bank (NEFT)')
+                await frm.set_value('transfer_type','Transfer to other bank (NEFT)');
             }
             frm.refresh_field("transfer_type");
         }

--- a/bank_integration/scripts/payment_entry.js
+++ b/bank_integration/scripts/payment_entry.js
@@ -109,10 +109,10 @@ frappe.ui.form.on('Payment Entry', {
 
     paid_amount: function(frm){
         set_transfer_type(frm);
-        if (frm.doc.paid_amount>=200000 && frm.doc.transfer_type!="Transfer within the bank"){
+        if (frm.doc.paid_amount>=200000 && frm.doc.transfer_type!="Transfer within the bank" && frm.doc.transfer_type!="Transfer to other bank (NEFT)" && frm.doc.transfer_type!="Transfer to other bank (IMPS)"){
             frm.set_value('transfer_type', 'Transfer to other bank (RTGS)');
             frm.refresh_field('transfer_type')
-        }else if(frm.doc.transfer_type!="Transfer within the bank"){
+        }else if(frm.doc.transfer_type!="Transfer within the bank" && frm.doc.transfer_type!="Transfer to other bank (IMPS)"){
             frm.set_value('transfer_type', 'Transfer to other bank (NEFT)');
             frm.refresh_field('transfer_type')
         }

--- a/bank_integration/scripts/payment_entry.js
+++ b/bank_integration/scripts/payment_entry.js
@@ -124,6 +124,7 @@ frappe.ui.form.on("Payment Entry", {
             frm.doc.party_bank &&
             frm.doc.paid_amount < 200000 &&
             frm.doc.transfer_type != "Transfer within the bank" &&
+            frm.doc.transfer_type != "Transfer to other bank (NEFT)" &&
             frm.doc.transfer_type != "Transfer to other bank (IMPS)"
         ) {
             await frm.set_value(
@@ -142,7 +143,7 @@ frappe.ui.form.on("Payment Entry", {
     },
 
     transfer_type: function(frm){
-        if (frm.doc.transfer_type == 'Transfer to other bank (NEFT)'){
+        if (frm.doc.transfer_type && frm.doc.transfer_type.includes('Transfer to other bank')){
             frm.toggle_reqd('comm_type', 1);
             frm.set_value('comm_type', 'Email');
         } else {

--- a/bank_integration/scripts/payment_entry.js
+++ b/bank_integration/scripts/payment_entry.js
@@ -109,10 +109,7 @@ frappe.ui.form.on('Payment Entry', {
 
     paid_amount: function(frm){
         set_transfer_type(frm);
-        if (frm.doc.paid_amount>=200000 && frm.doc.transfer_type!="Transfer within the bank" && frm.doc.transfer_type!="Transfer to other bank (NEFT)" && frm.doc.transfer_type!="Transfer to other bank (IMPS)"){
-            frm.set_value('transfer_type', 'Transfer to other bank (RTGS)');
-            frm.refresh_field('transfer_type')
-        }else if(frm.doc.transfer_type!="Transfer within the bank" && frm.doc.transfer_type!="Transfer to other bank (IMPS)"){
+        if(frm.doc.paid_amount<200000 && frm.doc.transfer_type!="Transfer within the bank" && frm.doc.transfer_type!="Transfer to other bank (IMPS)"){
             frm.set_value('transfer_type', 'Transfer to other bank (NEFT)');
             frm.refresh_field('transfer_type')
         }

--- a/bank_integration/scripts/payment_entry.js
+++ b/bank_integration/scripts/payment_entry.js
@@ -2,18 +2,11 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Payment Entry', {
-    setup: function(frm) {
-        if(frm._eval_js_handler){
-			frappe.realtime.off("eval_js", frm._eval_js_handler);
-		}
-        frappe.realtime.on("eval_js", function(message){
-            eval(message);
-        })
-        frm._eval_js_handler = function(message) {
-                eval(message);
-            };
-        frappe.realtime.on("eval_js", frm._eval_js_handler);    
-    },
+    setup(frm) {
+		frappe.realtime.on("eval_js", function(message){
+			eval(message);
+		});
+	},
 	
     onload: function(frm) {
         bi.listenForOtp(frm);

--- a/bank_integration/scripts/payment_entry.js
+++ b/bank_integration/scripts/payment_entry.js
@@ -1,14 +1,14 @@
 // Copyright (c) 2018, Resilient Tech and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('Payment Entry', {
+frappe.ui.form.on("Payment Entry", {
     setup(frm) {
-		frappe.realtime.on("eval_js", function(message){
-			eval(message);
-		});
-	},
-	
-    onload: function(frm) {
+        frappe.realtime.on("eval_js", function (message) {
+            eval(message);
+        });
+    },
+
+    onload: function (frm) {
         bi.listenForOtp(frm);
         bi.listenForQuestions(frm);
 
@@ -23,67 +23,71 @@ frappe.ui.form.on('Payment Entry', {
             return false;
         });
 
-        frappe.realtime.on('payment_success', function(data){
+        frappe.realtime.on("payment_success", function (data) {
             if (data.uid != frm._uid || frm.success_action_started) {
                 return;
             }
 
             frm.success_action_started = true;
-            frappe.update_msgprint('Payment successful!');
-            setTimeout(function() {
+            frappe.update_msgprint("Payment successful!");
+            setTimeout(function () {
                 frappe.hide_msgprint();
-                frm.set_value('remarks', '');
-                frm.set_value('online_payment_status', 'Paid');
-                frm.set_value('reference_no',data.ref_no);
+                frm.set_value("remarks", "");
+                frm.set_value("online_payment_status", "Paid");
+                frm.set_value("reference_no", data.ref_no);
                 frm.refresh();
-                frm.save().then(function(){
+                frm.save().then(function () {
                     frm.savesubmit().then(() => {
                         if (frm.doc.comm_email) {
-                            let email_dialog = new frappe.views.CommunicationComposer({
-                                doc: frm.doc,
-                                frm: frm,
-                                subject: `Online Payment Processed (${frm.doc.name})`,
-                                recipients: frm.doc.comm_email,
-                                attach_document_print: true,
-                                message: `Hello,<br><br>
+                            let email_dialog =
+                                new frappe.views.CommunicationComposer({
+                                    doc: frm.doc,
+                                    frm: frm,
+                                    subject: `Online Payment Processed (${frm.doc.name})`,
+                                    recipients: frm.doc.comm_email,
+                                    attach_document_print: true,
+                                    message: `Hello,<br><br>
                                 A payment for ${fmt_money(frm.doc.paid_amount)} with Reference No. ${frm.doc.reference_no} has been made to your account on ${frappe.datetime.get_today()}. Enclosed is the payment note, with details of your invoices against which the said payment is made.<br><br>
                                 Feel free to get in touch with us if you have any queries or concerns.<br><br>
-                                Thank you for doing business with us. We look forward to your continued patronage in the future.<br><br>`
-                            });
+                                Thank you for doing business with us. We look forward to your continued patronage in the future.<br><br>`,
+                                });
 
-                            email_dialog.dialog.$wrapper.on('shown.bs.modal', () => {
-                                email_dialog.select_attachments();
-                            });
+                            email_dialog.dialog.$wrapper.on(
+                                "shown.bs.modal",
+                                () => {
+                                    email_dialog.select_attachments();
+                                },
+                            );
                         } else {
                             setup_sms(frm);
                             if (frm.sms_link) frm.sms_link.click();
                         }
-                    })
+                    });
                 });
             }, 1000);
             delete frm.success_action_started;
         });
     },
 
-    payment_type: function(frm){
+    payment_type: function (frm) {
         check_bank_integration(frm);
     },
 
-    paid_from: function(frm) {
+    paid_from: function (frm) {
         check_bank_integration(frm);
     },
 
-    party: function(frm) {
+    party: function (frm) {
         set_bank_name_and_ac(frm);
         get_contact_data(frm);
     },
 
-    pay_now: function(frm) {
+    pay_now: function (frm) {
         if (!frm.doc.paid_from_bank) {
             check_bank_integration(frm);
         }
 
-        if (frm.doc.payment_type != 'Pay'){
+        if (frm.doc.payment_type != "Pay") {
             return;
         }
 
@@ -92,123 +96,148 @@ frappe.ui.form.on('Payment Entry', {
 
         if (frm.doc.pay_now) {
             // Set reference details
-            frm.set_value('reference_no', '-');
-            frm.set_value('reference_date', frappe.datetime.get_today());
+            frm.set_value("reference_no", "-");
+            frm.set_value("reference_date", frappe.datetime.get_today());
 
             // Set mandatory
-            frm.toggle_reqd(['party_bank_ac_no', 'payment_desc', 'transfer_type'], 1)
+            frm.toggle_reqd(
+                ["party_bank_ac_no", "payment_desc", "transfer_type"],
+                1,
+            );
         } else {
-            reset_fields(frm, 'reference_no', 'reference_date');
-            frm.toggle_reqd(['party_bank_ac_no', 'payment_desc', 'transfer_type'], 0)
+            reset_fields(frm, "reference_no", "reference_date");
+            frm.toggle_reqd(
+                ["party_bank_ac_no", "payment_desc", "transfer_type"],
+                0,
+            );
         }
     },
 
-    party_bank: function(frm){
-        set_transfer_type(frm);
-    },
-
-    paid_amount: async function(frm){
+    party_bank: async function (frm) {
         await set_transfer_type(frm);
-        if(frm.doc.paid_amount<200000 && frm.doc.transfer_type!="Transfer within the bank" && frm.doc.transfer_type!="Transfer to other bank (IMPS)"){
-            await frm.set_value('transfer_type', 'Transfer to other bank (NEFT)');
-            frm.refresh_field('transfer_type')
+    },
+
+    paid_amount: async function (frm) {
+        await set_transfer_type(frm);
+        if (
+            frm.doc.paid_from_bank &&
+            frm.doc.party_bank &&
+            frm.doc.paid_amount < 200000 &&
+            frm.doc.transfer_type != "Transfer within the bank" &&
+            frm.doc.transfer_type != "Transfer to other bank (IMPS)"
+        ) {
+            await frm.set_value(
+                "transfer_type",
+                "Transfer to other bank (NEFT)",
+            );
+            frm.refresh_field("transfer_type");
         }
     },
 
-    payment_desc: function(frm){
-        frm.set_value('payment_desc', frm.doc.payment_desc.replace(/[^a-zA-Z0-9 ]/gi, ''));
+    payment_desc: function (frm) {
+        frm.set_value(
+            "payment_desc",
+            frm.doc.payment_desc.replace(/[^a-zA-Z0-9 ]/gi, ""),
+        );
     },
 
     transfer_type: function(frm){
-        if (frm.doc.transfer_type.includes('Transfer to other bank')){
+        if (frm.doc.transfer_type == 'Transfer to other bank (NEFT)'){
             frm.toggle_reqd('comm_type', 1);
             frm.set_value('comm_type', 'Email');
         } else {
-            frm.toggle_reqd('comm_type', 0);
-            reset_fields(frm, 'comm_type');
+            frm.toggle_reqd("comm_type", 0);
+            reset_fields(frm, "comm_type");
         }
     },
 
-    comm_type: function(frm) {
-        if(frm.doc.comm_type){
-            if (frm.doc.comm_type == 'Email'){
-                frm.toggle_reqd('comm_email', 1);
-                frm.toggle_reqd('comm_mobile', 0);
-            } else if (frm.doc.comm_type == 'Mobile'){
-                frm.toggle_reqd('comm_mobile', 1);
-                frm.toggle_reqd('comm_email', 0);
+    comm_type: function (frm) {
+        if (frm.doc.comm_type) {
+            if (frm.doc.comm_type == "Email") {
+                frm.toggle_reqd("comm_email", 1);
+                frm.toggle_reqd("comm_mobile", 0);
+            } else if (frm.doc.comm_type == "Mobile") {
+                frm.toggle_reqd("comm_mobile", 1);
+                frm.toggle_reqd("comm_email", 0);
             }
         } else {
-            frm.toggle_reqd(['comm_email', 'comm_mobile'], 0);
+            frm.toggle_reqd(["comm_email", "comm_mobile"], 0);
         }
     },
 
-    validate: function(frm) {
-        if (frm.doc.docstatus === 0){
-            if (frm.get_docfield('pay_now').hidden_due_to_dependency){
-                frm.set_value('pay_now', 0);
+    validate: function (frm) {
+        if (frm.doc.docstatus === 0) {
+            if (frm.get_docfield("pay_now").hidden_due_to_dependency) {
+                frm.set_value("pay_now", 0);
             } else if (frm.doc.pay_now && !frm.doc.online_payment_status) {
-                frm.doc.online_payment_status = 'Unpaid';
+                frm.doc.online_payment_status = "Unpaid";
             }
         }
     },
     before_submit: function (frm) {
         if (frm.doc.pay_now && frm.doc.online_payment_status != "Paid") {
             frappe.throw({
-                "title": __("Warning"),
-                "message": __("Payment not made !"),
-                "indicator": "orange"
-            })
+                title: __("Warning"),
+                message: __("Payment not made !"),
+                indicator: "orange",
+            });
         }
     },
 
-    refresh: function(frm) {
+    refresh: async function (frm) {
         if (frm.doc.docstatus === 0) {
             frm.fields_dict.payment_desc.$input[0].maxLength = 20;
             frm.fields_dict.comm_mobile.$input[0].maxLength = 10;
         }
 
-        if (frm.doc.docstatus === 0 && !frm.doc.__unsaved){
-            if (frm.doc.pay_now && frm.doc.online_payment_status == 'Unpaid'){
-                var comm_value = '';
-                if (frm.doc.comm_type == 'Email') {
+        if (frm.doc.docstatus === 0 && !frm.doc.__unsaved) {
+            if (frm.doc.pay_now && frm.doc.online_payment_status == "Unpaid") {
+                var comm_value = "";
+                if (frm.doc.comm_type == "Email") {
                     comm_value = frm.doc.comm_email;
-                } else if (frm.doc.comm_type == 'Mobile') {
+                } else if (frm.doc.comm_type == "Mobile") {
                     comm_value = frm.doc.comm_mobile;
                 }
 
-                set_transfer_type(frm)
+                await set_transfer_type(frm);
 
-                frm.add_custom_button(__('Make Online Payment'), function() {
-                    frappe.confirm(`Are you sure you want to proceed with the following details? <br>
+                frm.add_custom_button(__("Make Online Payment"), function () {
+                    frappe.confirm(
+                        `Are you sure you want to proceed with the following details? <br>
                     <br> Party's Bank Account No: <strong>${frm.doc.party_bank_ac_no}</strong>
                     <br> Transfer Type: <strong>${frm.doc.transfer_type}</strong>
                     <br> Amount Payable: <strong>${fmt_money(frm.doc.paid_amount)}</strong>
                     <br> Description: <strong>${frm.doc.payment_desc}</strong>`,
-                    function() {
-                        frm._uid = frappe.utils.get_random(7);
-                        let payment_data = {
-                            from_account: frm.doc.paid_from,
-                            to_account: frm.doc.party_bank_ac_no,
-                            transfer_type: frm.doc.transfer_type,
-                            amount: frm.doc.paid_amount,
-                            payment_desc: frm.doc.payment_desc,
-                            comm_type: frm.doc.comm_type,
-                            comm_value: comm_value ? comm_value.trim().replace(" ", "") : ''
-                        }
+                        function () {
+                            frm._uid = frappe.utils.get_random(7);
+                            let payment_data = {
+                                from_account: frm.doc.paid_from,
+                                to_account: frm.doc.party_bank_ac_no,
+                                transfer_type: frm.doc.transfer_type,
+                                amount: frm.doc.paid_amount,
+                                payment_desc: frm.doc.payment_desc,
+                                comm_type: frm.doc.comm_type,
+                                comm_value: comm_value
+                                    ? comm_value.trim().replace(" ", "")
+                                    : "",
+                            };
 
-                        frappe.call({
-                            method: "bank_integration.bank_integration.api.payments.make_payment",
-                            args: {docname: frm.doc.name, uid: frm._uid, data: payment_data},
-                        });
-                    });
+                            frappe.call({
+                                method: "bank_integration.bank_integration.api.payments.make_payment",
+                                args: {
+                                    docname: frm.doc.name,
+                                    uid: frm._uid,
+                                    data: payment_data,
+                                },
+                            });
+                        },
+                    );
                 });
-
             }
         }
 
         setup_sms(frm);
-    }
+    },
 });
 
 
@@ -316,11 +345,11 @@ function setup_sms(frm) {
 function check_bank_integration(frm){
     if(frm.doc.payment_type == 'Pay' && frm.doc.paid_from) {
         frappe.db.get_value('Bank Account', {'account': frm.doc.paid_from}, ['name', 'bank'])
-        .then((r) => {
+        .then(async (r) => {
             if(r.message){
                 frm.set_value('paid_from_bank', r.message.bank ? r.message.bank : '');
                 if (frm.doc.paid_from_bank) {
-                    set_transfer_type(frm);
+                    await set_transfer_type(frm);
                 }
 
                 frappe.db.get_value('Bank Integration Settings', {name: r.message.name, disabled: false}, 'name').then((r) => {
@@ -359,12 +388,12 @@ function set_bank_name_and_ac(frm) {
     }
 }
 
-async function set_transfer_type(frm) {
+function set_transfer_type(frm) {
     if(frm.doc.paid_from_bank && frm.doc.party_bank) {
         if(frm.doc.paid_from_bank == frm.doc.party_bank){
             frm.set_df_property("transfer_type","options",
                 ["Transfer within the bank"].join("\n"))
-            await frm.set_value('transfer_type', 'Transfer within the bank');
+            frm.set_value('transfer_type', 'Transfer within the bank');
         } else {
             frm.set_df_property("transfer_type", "options", [
             "Transfer to other bank (NEFT)",
@@ -372,12 +401,12 @@ async function set_transfer_type(frm) {
             ...(frm.doc.paid_amount >= 200000 ? ["Transfer to other bank (RTGS)"] : [])
             ].join("\n"));
             if(frm.doc.transfer_type=="Transfer within the bank" || frm.doc.transfer_type==""){
-                await frm.set_value('transfer_type','Transfer to other bank (NEFT)');
+                frm.set_value('transfer_type','Transfer to other bank (NEFT)')
             }
             frm.refresh_field("transfer_type");
         }
     } else {
-        reset_fields(frm, 'transfer_type');
+        reset_fields(frm, "transfer_type");
     }
 }
 

--- a/bank_integration/scripts/payment_entry.js
+++ b/bank_integration/scripts/payment_entry.js
@@ -3,12 +3,19 @@
 
 frappe.ui.form.on('Payment Entry', {
     setup: function(frm) {
+        if(frm._eval_js_handler){
+			frappe.realtime.off("eval_js", frm._eval_js_handler);
+		}
         frappe.realtime.on("eval_js", function(message){
             eval(message);
         })
+        frm._eval_js_handler = function(message) {
+                eval(message);
+            };
+        frappe.realtime.on("eval_js", frm._eval_js_handler);    
     },
-
-	onload: function(frm) {
+	
+    onload: function(frm) {
         bi.listenForOtp(frm);
         bi.listenForQuestions(frm);
 
@@ -107,6 +114,17 @@ frappe.ui.form.on('Payment Entry', {
         set_transfer_type(frm);
     },
 
+    paid_amount: function(frm){
+        set_transfer_type(frm);
+        if (frm.doc.paid_amount>=200000){
+            frm.set_value('transfer_type', 'Transfer to other bank (RTGS)');
+            frm.refresh_field('transfer_type')
+        }else{
+            frm.set_value('transfer_type', 'Transfer to other bank (NEFT)');
+            frm.refresh_field('transfer_type')
+        }
+    },
+
     payment_desc: function(frm){
         frm.set_value('payment_desc', frm.doc.payment_desc.replace(/[^a-zA-Z0-9 ]/gi, ''));
     },
@@ -168,6 +186,8 @@ frappe.ui.form.on('Payment Entry', {
                 } else if (frm.doc.comm_type == 'Mobile') {
                     comm_value = frm.doc.comm_mobile;
                 }
+
+                set_transfer_type(frm)
 
                 frm.add_custom_button(__('Make Online Payment'), function() {
                     frappe.confirm(`Are you sure you want to proceed with the following details? <br>
@@ -352,9 +372,16 @@ function set_bank_name_and_ac(frm) {
 function set_transfer_type(frm) {
     if(frm.doc.paid_from_bank && frm.doc.party_bank) {
         if(frm.doc.paid_from_bank == frm.doc.party_bank){
+            frm.set_df_property("transfer_type","options",
+                ["Transfer within the bank"])
             frm.set_value('transfer_type', 'Transfer within the bank');
         } else {
-            frm.set_value('transfer_type', 'Transfer to other bank (NEFT)');
+            frm.set_df_property("transfer_type", "options", [
+            "Transfer to other bank (NEFT)",
+            "Transfer to other bank (IMPS)",
+            ...(frm.doc.paid_amount >= 200000 ? ["Transfer to other bank (RTGS)"] : [])
+            ].join("\n"));
+            frm.refresh_field("transfer_type");
         }
     } else {
         reset_fields(frm, 'transfer_type');

--- a/bank_integration/scripts/payment_entry.js
+++ b/bank_integration/scripts/payment_entry.js
@@ -374,7 +374,9 @@ function set_transfer_type(frm) {
             "Transfer to other bank (IMPS)",
             ...(frm.doc.paid_amount >= 200000 ? ["Transfer to other bank (RTGS)"] : [])
             ].join("\n"));
-            frm.set_value('transfer_type','Transfer to other bank (NEFT)')
+            if(frm.doc.transfer_type=="Transfer within the bank"){
+                frm.set_value('transfer_type','Transfer to other bank (NEFT)')
+            }
             frm.refresh_field("transfer_type");
         }
     } else {


### PR DESCRIPTION
Closes: #19 

## Description

Previously, the only supported transfer mode for inter-bank payments was NEFT in inter-bank transfers. This PR adds support for **IMPS** and **RTGS** as transfer options.

### What changed

**Frontend (`payment_entry.js`)**
- The **Bank Transfer Type** dropdown now shows NEFT and IMPS for all inter-bank payments.
- **RTGS is automatically added** as an option (not selected) when the payment amount is ₹2,00,000 or above (RBI minimum for RTGS).

**Backend (`hdfc_bank_api.py`)**
- Renamed `make_neft_payment` → `make_inter_bank_payment` since it now handles all three modes.
- After entering the amount, the automation clicks the correct transfer mode button (NEFT / IMPS / RTGS) on the HDFC portal based on the selected transfer type.
- The condition to route into inter-bank payment was generalised — instead of checking for the exact string `"Transfer to other bank (NEFT)"`, it now matches any `"Transfer to other bank (...)"` value.
