### PR TITLE
fix: proceed option coming after otp submission

### DIFF
--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -279,11 +279,11 @@ class HDFCBankAPI(BankAPI):
         
         try:
             self.br.switch_to.default_content()
-            proceed_btn = self.get_element("proceedBtn", "id", timeout=10)
+            proceed_btn = self.get_element("proceedBtn", "id", timeout=8,throw="ignore")
             if proceed_btn:
                 proceed_btn.click()
                 # proceed btn prompt comes twice in the UI
-                proceed_btn = self.get_element("proceedBtn", "id", timeout=10)
+                proceed_btn = self.get_element("proceedBtn", "id", timeout=8,throw="ignore")
                 proceed_btn.click()
         except Exception:
             pass

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -276,6 +276,18 @@ class HDFCBankAPI(BankAPI):
             self.br.execute_script("arguments[0].click();", submit_btn)
         else:
             self.throw("Could not find OTP Submit button.", screenshot=True)
+        
+        try:
+            self.br.switch_to.default_content()
+            proceed_btn = self.get_element("proceedBtn", "id", timeout=10)
+            if proceed_btn:
+                proceed_btn.click()
+                # proceed btn prompt comes twice in the UI
+                proceed_btn = self.get_element("proceedBtn", "id", timeout=10)
+                proceed_btn.click()
+        except Exception:
+            pass
+
 
     def submit_answers(self, answers):
         field_map = self.get_question_map(True)

--- a/license.txt
+++ b/license.txt
@@ -1,1 +1,21 @@
-License: MIT
+The MIT License
+
+Copyright (c) 2018 Resilient Tech <info@resilient.tech>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
## Description

This change fixes an issue where the **“Proceed”** option was appearing **after OTP submission**.  Occurs when it's already logged in at other place.

The logic has been updated so that the **Proceed** option that appears after the OTP has been submitted**, is handled correctly.


