### PR TITLE
Bulk payment with refactored eval js

### DIFF
--- a/bank_integration/bank_integration/api/bank_api.py
+++ b/bank_integration/bank_integration/api/bank_api.py
@@ -91,7 +91,7 @@ class BankAPI:
             docname=self.docname,
         )
 
-    def show_msg(self, msg, is_bulk_payment):
+    def show_msg(self, msg, is_bulk_payment=None):
         if is_bulk_payment is None:
             self.emit_js("frappe.update_msgprint(`{0}`);".format(msg))
         else:

--- a/bank_integration/bank_integration/api/bank_api.py
+++ b/bank_integration/bank_integration/api/bank_api.py
@@ -110,6 +110,8 @@ class BankAPI:
             self.bulk_payments = cached["bulk_data"]
         if "is_bulk_payments" in cached:
             self.is_bulk_payments = cached["is_bulk_payments"]
+        if "remove_payment" in cached:
+            self.remove_payment = cached["remove_payment"]
 
         resume_info = frappe._dict(cached["resume_info"])
 
@@ -204,6 +206,7 @@ class BankAPI:
                     "data": self.data,
                     "bulk_data": self.bulk_payments,
                     "is_bulk_payments": self.is_bulk_payments,
+                    "remove_payment":self.remove_payment,
                 },
                 user=frappe.session.user,
             )

--- a/bank_integration/bank_integration/api/bank_api.py
+++ b/bank_integration/bank_integration/api/bank_api.py
@@ -97,8 +97,7 @@ class BankAPI:
             docname=self.docname,
         )
 
-    def show_msg(self, msg, is_bulk_payments=None):
-        # Always publish to the standard eval_js event, list view listener handles the message.
+    def show_msg(self, msg):
         self.emit_js("frappe.update_msgprint(`{0}`);".format(msg))
 
     def get_resume_info(self):

--- a/bank_integration/bank_integration/api/bank_api.py
+++ b/bank_integration/bank_integration/api/bank_api.py
@@ -84,21 +84,14 @@ class BankAPI:
 
         return options
 
-    def emit_js(self, js):
-        js = "if ((cur_frm && cur_frm._uid === '{0}') || (cur_list && cur_list._uid === '{0}')) {{ {1} }}".format(
-            self.uid, js
-        )
-
+    def show_msg(self, msg):
         frappe.publish_realtime(
-            "eval_js",
-            js,
+            "bi_action",
+            {"message": msg, "uid": self.uid, "action": "show_message"},
             user=frappe.session.user,
             doctype=self.doctype,
             docname=self.docname,
         )
-
-    def show_msg(self, msg):
-        self.emit_js("frappe.update_msgprint(`{0}`);".format(msg))
 
     def get_resume_info(self):
         return {
@@ -174,7 +167,6 @@ class BankAPI:
             raise
 
     def throw(self, message, screenshot=False):
-        js = "frappe.hide_msgprint();"
         if screenshot:
             save_file(
                 "payment_error_{}.png".format(self.uid),
@@ -185,10 +177,15 @@ class BankAPI:
             )
 
             frappe.db.commit()
-            js += " if (cur_frm) cur_frm.reload_doc();"
             message += " (See attached screenshot)"
 
-        self.emit_js(js)
+        frappe.publish_realtime(
+            "bi_action",
+            {"docname": self.docname, "uid": self.uid, "action": "reload_doc"},
+            user=frappe.session.user,
+            doctype=self.doctype,
+            docname=self.docname,
+        )
         self.logout()
         frappe.throw(message)
 

--- a/bank_integration/bank_integration/api/bank_api.py
+++ b/bank_integration/bank_integration/api/bank_api.py
@@ -40,7 +40,10 @@ class BankAPI:
         self.data = data
         self.bulk_payments = bulk_payments
         self.remove_payment = True
-        
+        if bulk_payments is None:
+            self.is_bulk_payments = False
+        else:
+            self.is_bulk_payments = True
 
         if getattr(self, "init"):
             self.init()
@@ -58,7 +61,8 @@ class BankAPI:
 
     def setup_browser(self):
         from selenium.webdriver.remote.remote_connection import RemoteConnection
-        if not isinstance(RemoteConnection._timeout, (int, float)) :
+
+        if not isinstance(RemoteConnection._timeout, (int, float)):
             RemoteConnection.set_timeout(90)
         self.br = webdriver.Chrome(options=self.get_options())
 
@@ -81,7 +85,9 @@ class BankAPI:
         return options
 
     def emit_js(self, js):
-        js = "if (cur_frm && cur_frm._uid === '{0}') {{ {1} }}".format(self.uid, js)
+        js = "if ((cur_frm && cur_frm._uid === '{0}') || (cur_list && cur_list._uid === '{0}')) {{ {1} }}".format(
+            self.uid, js
+        )
 
         frappe.publish_realtime(
             "eval_js",
@@ -91,18 +97,9 @@ class BankAPI:
             docname=self.docname,
         )
 
-    def show_msg(self, msg, is_bulk_payment=None):
-        if is_bulk_payment is None:
-            self.emit_js("frappe.update_msgprint(`{0}`);".format(msg))
-        else:
-            js = "frappe.update_msgprint(`{0}`);".format(msg)
-            frappe.publish_realtime(
-                "eval_js_bulk",
-                js,
-                user=frappe.session.user,
-                doctype=self.doctype,
-                docname=self.docname,
-            )
+    def show_msg(self, msg, is_bulk_payments=None):
+        # Always publish to the standard eval_js event, list view listener handles the message.
+        self.emit_js("frappe.update_msgprint(`{0}`);".format(msg))
 
     def get_resume_info(self):
         return {
@@ -116,13 +113,18 @@ class BankAPI:
             self.throw("Unable to find session info in cache")
 
         self.data = frappe._dict(cached["data"] or {})
+
         if "bulk_data" in cached:
             self.bulk_payments = cached["bulk_data"]
+        if "is_bulk_payments" in cached:
+            self.is_bulk_payments = cached["is_bulk_payments"]
+
         resume_info = frappe._dict(cached["resume_info"])
 
         self.br = webdriver.Remote(
             command_executor=resume_info.executor_url, options=self.get_options()
         )
+
         self.br.close()
         self.br.session_id = resume_info.session_id
 
@@ -192,7 +194,7 @@ class BankAPI:
         frappe.throw(message)
 
     def save_for_later(self):
-        if self.bulk_payments is None:
+        if not self.is_bulk_payments:
             frappe.cache().set_value(
                 self.cache_key,
                 {"resume_info": self.get_resume_info(), "data": self.data},
@@ -205,6 +207,7 @@ class BankAPI:
                     "resume_info": self.get_resume_info(),
                     "data": self.data,
                     "bulk_data": self.bulk_payments,
+                    "is_bulk_payments": self.is_bulk_payments,
                 },
                 user=frappe.session.user,
             )

--- a/bank_integration/bank_integration/api/bank_api.py
+++ b/bank_integration/bank_integration/api/bank_api.py
@@ -27,6 +27,7 @@ class BankAPI:
         uid=None,
         resume=False,
         data=None,
+        bulk_payments=None,
     ):
         self.username = username
         self.password = password
@@ -37,6 +38,8 @@ class BankAPI:
         self.uid = uid or frappe.utils.random_string(7)
         self.cache_key = "bank_" + self.uid
         self.data = data
+        self.bulk_payments = bulk_payments
+        self.remove_payment = True
         
 
         if getattr(self, "init"):
@@ -79,6 +82,7 @@ class BankAPI:
 
     def emit_js(self, js):
         js = "if (cur_frm && cur_frm._uid === '{0}') {{ {1} }}".format(self.uid, js)
+
         frappe.publish_realtime(
             "eval_js",
             js,
@@ -87,8 +91,18 @@ class BankAPI:
             docname=self.docname,
         )
 
-    def show_msg(self, msg):
-        self.emit_js("frappe.update_msgprint(`{0}`);".format(msg))
+    def show_msg(self, msg, is_bulk_payment):
+        if is_bulk_payment is None:
+            self.emit_js("frappe.update_msgprint(`{0}`);".format(msg))
+        else:
+            js = "frappe.update_msgprint(`{0}`);".format(msg)
+            frappe.publish_realtime(
+                "eval_js_bulk",
+                js,
+                user=frappe.session.user,
+                doctype=self.doctype,
+                docname=self.docname,
+            )
 
     def get_resume_info(self):
         return {
@@ -102,6 +116,8 @@ class BankAPI:
             self.throw("Unable to find session info in cache")
 
         self.data = frappe._dict(cached["data"] or {})
+        if "bulk_data" in cached:
+            self.bulk_payments = cached["bulk_data"]
         resume_info = frappe._dict(cached["resume_info"])
 
         self.br = webdriver.Remote(
@@ -176,12 +192,22 @@ class BankAPI:
         frappe.throw(message)
 
     def save_for_later(self):
-        frappe.cache().set_value(
-            self.cache_key,
-            {"resume_info": self.get_resume_info(), "data": self.data},
-            user=frappe.session.user,
-        )
-
+        if self.bulk_payments is None:
+            frappe.cache().set_value(
+                self.cache_key,
+                {"resume_info": self.get_resume_info(), "data": self.data},
+                user=frappe.session.user,
+            )
+        else:
+            frappe.cache().set_value(
+                self.cache_key,
+                {
+                    "resume_info": self.get_resume_info(),
+                    "data": self.data,
+                    "bulk_data": self.bulk_payments,
+                },
+                user=frappe.session.user,
+            )
         setattr(bank_integration, self.cache_key, self)
 
     def delete_cache(self):

--- a/bank_integration/bank_integration/api/decorators.py
+++ b/bank_integration/bank_integration/api/decorators.py
@@ -16,6 +16,7 @@ def set_correct_payment_data(func):
             raise Exception("No payment data available")
 
         self.data = data
+        self.docname = data.docname
 
         return func(self, *args, **kwargs)
 

--- a/bank_integration/bank_integration/api/decorators.py
+++ b/bank_integration/bank_integration/api/decorators.py
@@ -1,0 +1,25 @@
+from frappe import _dict
+from functools import wraps
+
+def set_correct_payment_data(func):
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        if getattr(self, "bulk_payments", None):
+            if self.remove_payment:
+                data = _dict(self.bulk_payments.pop())
+            else:
+                data = self.data
+        else:
+            data = getattr(self, "data", None)
+
+        if not data:
+            raise Exception("No payment data available")
+
+        self.data = data
+
+        try:
+            return func(self, *args, **kwargs)
+        except Exception:
+            self.throw("Some internal error")
+
+    return wrapper

--- a/bank_integration/bank_integration/api/decorators.py
+++ b/bank_integration/bank_integration/api/decorators.py
@@ -13,7 +13,7 @@ def set_correct_payment_data(func):
             data = getattr(self, "data", None)
 
         if not data:
-            raise self.throw("No payment data available")
+            self.throw("No payment data available")
 
         self.data = data
 

--- a/bank_integration/bank_integration/api/decorators.py
+++ b/bank_integration/bank_integration/api/decorators.py
@@ -6,7 +6,7 @@ def set_correct_payment_data(func):
     def wrapper(self, *args, **kwargs):
         if getattr(self, "bulk_payments", None):
             if self.remove_payment:
-                data = _dict(self.bulk_payments.pop())
+                data = _dict(self.bulk_payments.pop(0))
             else:
                 data = self.data
         else:

--- a/bank_integration/bank_integration/api/decorators.py
+++ b/bank_integration/bank_integration/api/decorators.py
@@ -17,9 +17,6 @@ def set_correct_payment_data(func):
 
         self.data = data
 
-        try:
-            return func(self, *args, **kwargs)
-        except Exception:
-            self.throw("Some internal error")
+        return func(self, *args, **kwargs)
 
     return wrapper

--- a/bank_integration/bank_integration/api/decorators.py
+++ b/bank_integration/bank_integration/api/decorators.py
@@ -13,7 +13,7 @@ def set_correct_payment_data(func):
             data = getattr(self, "data", None)
 
         if not data:
-            raise Exception("No payment data available")
+            raise self.throw("No payment data available")
 
         self.data = data
 

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -27,7 +27,7 @@ class HDFCBankAPI(BankAPI):
         self.bank_name = "HDFC Bank"
 
     def login(self):
-        self.show_msg("Attempting login...", self.is_bulk_payments)
+        self.show_msg("Attempting login...")
         self.setup_browser()
         self.br.get("https://netbanking.hdfcbank.com/netbanking/")
 
@@ -346,11 +346,11 @@ class HDFCBankAPI(BankAPI):
         self.logged_in = 1
 
         if self.doctype == "Bank Integration Settings":
-            self.show_msg("Credentials verified successfully!", self.bulk_payments)
+            self.show_msg("Credentials verified successfully!")
             self.emit_js("setTimeout(() => {frappe.hide_msgprint()}, 2000);")
             self.logout()
         elif self.doctype == "Payment Entry":
-            self.show_msg("Login Successful! Processing payment..", self.bulk_payments)
+            self.show_msg("Login Successful! Processing payment..")
             self.make_payment()
         elif self.doctype == "Bank Account":
             self.fetch_transactions()
@@ -372,8 +372,7 @@ class HDFCBankAPI(BankAPI):
                 time.sleep(1)
             except Exception:
                 self.show_msg(
-                    "We were unable to complete the logout process on the bank website. Please manually log out from your online banking account to end the session safely.",
-                    self.bulk_payments,
+                    "We were unable to complete the logout process on the bank website. Please manually log out from your online banking account to end the session safely."
                 )
         self.delete_cache()
         self.br.quit()
@@ -452,7 +451,7 @@ class HDFCBankAPI(BankAPI):
             if last4 and (last4 in selected_text.replace(" ", "")):
                 return
 
-        self.show_msg("Selecting from account...", self.bulk_payments)
+        self.show_msg("Selecting from account...")
 
         account_stripped = self.data.from_account.strip().replace(" ", "")
         last4 = account_stripped[-4:]
@@ -763,10 +762,8 @@ class HDFCBankAPI(BankAPI):
                 self.make_payment()
                 return
             else:
-                self.show_msg("All Payments are completed", self.bulk_payments)
-                js = "if(cur_list && cur_list._uid=='{0}'){setTimeout(()=>{frappe.hide_msgprint(); cur_list.refresh();cur_list.clear_checked_items();},4000);}".format(
-                    self.uid
-                )
+                self.show_msg("All Payments are completed")
+                js = f"if (cur_list && cur_list._uid === '{self.uid}') setTimeout(() => {{ frappe.hide_msgprint(); cur_list.refresh(); cur_list.clear_checked_items(); }}, 4000);"
                 frappe.publish_realtime(
                     "eval_js",
                     js,

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -748,6 +748,11 @@ class HDFCBankAPI(BankAPI):
                 docname=self.data.docname,
             )
         else:
+            if getattr(self, "bulk_payments", None):
+                is_last=False
+            else:
+                is_last=True
+
             frappe.publish_realtime(
                 "bi_action",
                 {
@@ -757,6 +762,7 @@ class HDFCBankAPI(BankAPI):
                     "docname": self.data.docname,
                     "party_name":self.data.party_name,
                     "action": "payment_success_bulk",
+                    "is_last": is_last,
                 },
                 user=frappe.session.user,
                 doctype="Payment Entry",
@@ -778,7 +784,6 @@ class HDFCBankAPI(BankAPI):
                 self.make_payment()
                 return
             else:
-                self.show_msg("All Payments are completed")
                 frappe.publish_realtime(
                     "bi_action",
                     {

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -718,6 +718,13 @@ class HDFCBankAPI(BankAPI):
             except Exception:
                 pass
 
+        self.remove_payment = True
+        payment_entry_doc = frappe.get_doc("Payment Entry", self.data.docname)
+        payment_entry_doc.online_payment_status = "Paid"
+        payment_entry_doc.reference_no = ref_no
+        payment_entry_doc.submit()
+        frappe.db.commit()
+
         # these are kept separate as one requires frm object which is not present in list view
         if not self.is_bulk_payments:
             frappe.publish_realtime(
@@ -743,13 +750,6 @@ class HDFCBankAPI(BankAPI):
                 doctype="Payment Entry",
                 docname=self.data.docname,
             )
-
-        self.remove_payment = True
-        payment_entry_doc = frappe.get_doc("Payment Entry", self.data.docname)
-        payment_entry_doc.online_payment_status = "Paid"
-        payment_entry_doc.reference_no = ref_no
-        payment_entry_doc.submit()
-        frappe.db.commit()
 
         if self.is_bulk_payments:
             if getattr(self, "bulk_payments", None):

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -36,8 +36,11 @@ class HDFCBankAPI(BankAPI):
         cust_id.send_keys(self.username, Keys.ENTER)
 
         self.br.switch_to.default_content()
-        pass_input = self.get_element("password", "id")
-
+        pass_input = self.get_element("password", "id", timeout=10,throw="ignore")
+        if pass_input is None:
+            self.throw(
+                "Credentials are incorrect. Please verify the username & password in Bank Integration Settings."
+            )
         pass_input.send_keys(self.password, Keys.ENTER)
 
         self.br.switch_to.default_content()
@@ -347,7 +350,13 @@ class HDFCBankAPI(BankAPI):
 
         if self.doctype == "Bank Integration Settings":
             self.show_msg("Credentials verified successfully!")
-            self.emit_js("setTimeout(() => {frappe.hide_msgprint()}, 2000);")
+            frappe.publish_realtime(
+                "bi_action",
+                {"uid": self.uid, "action": "login_success"},
+                user=frappe.session.user,
+                doctype=self.doctype,
+                docname=self.docname,
+            )
             self.logout()
         elif self.doctype == "Payment Entry":
             self.show_msg("Login Successful! Processing payment..")
@@ -728,10 +737,11 @@ class HDFCBankAPI(BankAPI):
         # these are kept separate as one requires frm object which is not present in list view
         if not self.is_bulk_payments:
             frappe.publish_realtime(
-                "payment_success",
+                "bi_action",
                 {
                     "ref_no": ref_no,
                     "uid": self.uid,
+                    "action": "payment_success",
                 },
                 user=frappe.session.user,
                 doctype="Payment Entry",
@@ -739,12 +749,13 @@ class HDFCBankAPI(BankAPI):
             )
         else:
             frappe.publish_realtime(
-                "payment_success_bulk",
+                "bi_action",
                 {
                     "ref_no": ref_no,
                     "uid": self.uid,
                     "paid_amount": self.data.amount,
                     "docname": self.data.docname,
+                    "action": "payment_success_bulk",
                 },
                 user=frappe.session.user,
                 doctype="Payment Entry",
@@ -766,10 +777,12 @@ class HDFCBankAPI(BankAPI):
                 return
             else:
                 self.show_msg("All Payments are completed")
-                js = "if(cur_list && cur_list._uid=='{0}'){{setTimeout(()=>{{frappe.hide_msgprint(); cur_list.refresh();cur_list.clear_checked_items();}},4000);}}".format(self.uid)
                 frappe.publish_realtime(
-                    "eval_js",
-                    js,
+                    "bi_action",
+                    {
+                        "uid": self.uid,
+                        "action": "bulk_payment_completed",
+                    },
                     user=frappe.session.user,
                     doctype=self.doctype,
                     docname=self.docname,

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -758,7 +758,10 @@ class HDFCBankAPI(BankAPI):
                     "xpath",
                     now=True,
                 )
-                self.br.execute_script("arguments[0].click();", send_money_btn)
+                if send_money_btn:
+                    self.br.execute_script("arguments[0].click();", send_money_btn)
+                else:
+                    self.throw("Send Money button not found.")
                 self.make_payment()
                 return
             else:

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -19,6 +19,7 @@ from selenium.common.exceptions import (
     TimeoutException,
 )
 from selenium.webdriver.common.keys import Keys
+from .decorators import set_correct_payment_data
 
 
 class HDFCBankAPI(BankAPI):
@@ -26,7 +27,7 @@ class HDFCBankAPI(BankAPI):
         self.bank_name = "HDFC Bank"
 
     def login(self):
-        self.show_msg("Attempting login...")
+        self.show_msg("Attempting login...", self.bulk_payments)
         self.setup_browser()
         self.br.get("https://netbanking.hdfcbank.com/netbanking/")
 
@@ -81,6 +82,15 @@ class HDFCBankAPI(BankAPI):
             found = self.br._found_element
 
             if not found:
+                if self.get_element(
+                    '//*[@id="bb-modal-dialog-header" and normalize-space(text())="Please reset your password!"]',
+                    "xpath",
+                    now=True,
+                    throw="ignore",
+                ):
+                    self.throw(
+                        "Please reset your password manually at the hdfc netbanking portal"
+                    )
                 if self.br.find_elements(By.ID, "mfa-get-otp-btn"):
                     self.process_otp()
                     return
@@ -169,7 +179,9 @@ class HDFCBankAPI(BankAPI):
             get_otp_btn.click()
         elif "mfa-get-otp-btn" == self.br._found_element[-1]:
             try:
-                email_mobile_otp_radio = self.get_element("channel-BOTH", "id",now=True)
+                email_mobile_otp_radio = self.get_element(
+                    "channel-BOTH", "id", now=True
+                )
                 email_mobile_otp_radio.click()
             except Exception:
                 pass
@@ -189,8 +201,12 @@ class HDFCBankAPI(BankAPI):
             except Exception:
                 pass
 
+        bulk = ""
+        if self.bulk_payments is not None:
+            bulk = "_bulk"
+
         frappe.publish_realtime(
-            "get_bank_otp",
+            "get_bank_otp" + bulk,
             {
                 "message": input_msg,
                 "uid": self.uid,
@@ -205,6 +221,9 @@ class HDFCBankAPI(BankAPI):
         self.save_for_later()
 
     def process_security_questions(self):
+        bulk = ""
+        if self.bulk_payments is not None:
+            bulk = "_bulk"
         frappe.publish_realtime(
             "get_bank_answers",
             {
@@ -243,16 +262,16 @@ class HDFCBankAPI(BankAPI):
 
         return question_map
 
-    def submit_otp_or_answers(self, otp=None, answers=None):
+    def submit_otp_or_answers(self, otp=None, answers=None, from_payment=False):
         if not otp and not answers:
             self.throw("Invalid response received. Exiting..")
 
         if otp:
-            self.submit_otp(otp)
+            self.submit_otp(otp, from_payment)
         else:
             self.submit_answers(answers)
 
-    def submit_otp(self, otp):
+    def submit_otp(self, otp, from_payment):
         # There can be multiple #otpValue elements in the DOM (one hidden
         # behind the modal, one visible inside it). Pick the visible one.
         otp_field = self.br.execute_script("""
@@ -276,18 +295,23 @@ class HDFCBankAPI(BankAPI):
             self.br.execute_script("arguments[0].click();", submit_btn)
         else:
             self.throw("Could not find OTP Submit button.", screenshot=True)
-        
-        try:
-            self.br.switch_to.default_content()
-            proceed_btn = self.get_element("proceedBtn", "id", timeout=8,throw="ignore")
-            if proceed_btn:
-                proceed_btn.click()
-                # proceed btn prompt comes twice in the UI
-                proceed_btn = self.get_element("proceedBtn", "id", timeout=8,throw="ignore")
-                proceed_btn.click()
-        except Exception:
-            pass
 
+        # checks for proceed btn after otp submit in login workflow only
+        if not from_payment:
+            try:
+                self.br.switch_to.default_content()
+                proceed_btn = self.get_element(
+                    "proceedBtn", "id", timeout=8, throw="ignore"
+                )
+                if proceed_btn:
+                    proceed_btn.click()
+                    # proceed btn prompt comes twice in the UI
+                    proceed_btn = self.get_element(
+                        "proceedBtn", "id", timeout=8, throw="ignore"
+                    )
+                    proceed_btn.click()
+            except Exception:
+                pass
 
     def submit_answers(self, answers):
         field_map = self.get_question_map(True)
@@ -327,8 +351,16 @@ class HDFCBankAPI(BankAPI):
             self.emit_js("setTimeout(() => {frappe.hide_msgprint()}, 2000);")
             self.logout()
         elif self.doctype == "Payment Entry":
-            self.show_msg("Login Successful! Processing payment..")
-            self.make_payment()
+            if self.bulk_payments:
+                self.show_msg(
+                    "Login Successful! Processing payments..", self.bulk_payments
+                )
+                self.make_payment()
+            else:
+                self.show_msg(
+                    "Login Successful! Processing payment..", self.bulk_payments
+                )
+                self.make_payment()
         elif self.doctype == "Bank Account":
             self.fetch_transactions()
 
@@ -349,24 +381,28 @@ class HDFCBankAPI(BankAPI):
                 time.sleep(1)
             except Exception:
                 self.show_msg(
-                    "We were unable to complete the logout process on the bank website. Please manually log out from your online banking account to end the session safely."
+                    "We were unable to complete the logout process on the bank website. Please manually log out from your online banking account to end the session safely.",
+                    self.bulk_payments,
                 )
         self.delete_cache()
         self.br.quit()
 
+    @set_correct_payment_data
     def make_payment(self):
+        self.remove_payment = False
         self.br.switch_to.default_content()
-        clicked = self.br.execute_script("""
-            var el = document.querySelector("a[routerlink='/transfers/send-money']");
-            if (el) { el.click(); return true; }
-            return false;
-        """)
-        if not clicked:
-            self.throw(
-                "Could not find the 'Send Money' navigation link. The HDFC portal layout may have changed."
-            )
+        if "/transfers/send-money" not in self.br.current_url:
+            clicked = self.br.execute_script("""
+                var el = document.querySelector("a[routerlink='/transfers/send-money']");
+                if (el) { el.click(); return true; }
+                return false;
+            """)
+            if not clicked:
+                self.throw(
+                    "Could not find the 'Send Money' navigation link. The HDFC portal layout may have changed."
+                )
 
-        self.wait_until(EC.url_contains("/transfers/send-money"))
+            self.wait_until(EC.url_contains("/transfers/send-money"))
 
         to_account_input_box = self.get_element("typeahead-template", "id")
         to_account_input_box.click()
@@ -380,7 +416,9 @@ class HDFCBankAPI(BankAPI):
             )
             option.click()
         except Exception:
-            self.throw("Could not find party's bank account in the list of Payees. Please add it manually")
+            self.throw(
+                "Could not find party's bank account in the list of Payees. Please add it manually"
+            )
 
         self._select_from_account_if_needed()
 
@@ -389,6 +427,7 @@ class HDFCBankAPI(BankAPI):
         elif self.data.transfer_type == "Transfer to other bank (NEFT)":
             self.make_neft_payment()
 
+    @set_correct_payment_data
     def _select_from_account_if_needed(self):
         """
         After the to-account is selected, HDFC may show an ng-select dropdown
@@ -422,7 +461,7 @@ class HDFCBankAPI(BankAPI):
             if last4 and (last4 in selected_text.replace(" ", "")):
                 return
 
-        self.show_msg("Selecting from account...")
+        self.show_msg("Selecting from account...", self.bulk_payments)
 
         account_stripped = self.data.from_account.strip().replace(" ", "")
         last4 = account_stripped[-4:]
@@ -535,6 +574,7 @@ class HDFCBankAPI(BankAPI):
         else:
             self.payment_success()
 
+    @set_correct_payment_data
     def make_payment_within_bank(self):
         amt = self.get_element("transfer-amount-input", "id")
         amt.clear()
@@ -627,7 +667,7 @@ class HDFCBankAPI(BankAPI):
 
     def continue_payment(self, otp=None, answers=None):
         self.br.switch_to.default_content()
-        self.submit_otp_or_answers(otp, answers)
+        self.submit_otp_or_answers(otp, answers, from_payment=True)
 
         try:
             self.br.switch_to.default_content()
@@ -652,14 +692,22 @@ class HDFCBankAPI(BankAPI):
         details_button = self.get_element("showHideBtn", "id")
         details_button.click()
 
-        save_file(
-            self.docname + " Online Payment Screenshot.png",
-            self.br.get_screenshot_as_png(),
-            self.doctype,
-            self.docname,
-            is_private=1,
-        )
-
+        if self.data.docname:
+            save_file(
+                self.data.docname + " Online Payment Screenshot.png",
+                self.br.get_screenshot_as_png(),
+                self.data.doctype,
+                self.data.docname,
+                is_private=1,
+            )
+        else:
+            save_file(
+                self.docname + " Online Payment Screenshot.png",
+                self.br.get_screenshot_as_png(),
+                self.doctype,
+                self.docname,
+                is_private=1,
+            )
         ref_no = "-"
         if self.data.transfer_type == "Transfer within the bank":
             try:
@@ -687,14 +735,52 @@ class HDFCBankAPI(BankAPI):
             except Exception:
                 pass
 
-        frappe.publish_realtime(
-            "payment_success",
-            {"ref_no": ref_no, "uid": self.uid},
-            user=frappe.session.user,
-            doctype="Payment Entry",
-            docname=self.docname,
-        )
+        if self.bulk_payments is None:
+            frappe.publish_realtime(
+                "payment_success",
+                {"ref_no": ref_no, "uid": self.uid},
+                user=frappe.session.user,
+                doctype="Payment Entry",
+                docname=self.docname,
+            )
+            self.remove_payment = True
 
+        else:
+            frappe.publish_realtime(
+                "payment_success_bulk",
+                {"ref_no": ref_no, "uid": self.uid, "paid_amount": self.data.amount,"docname":self.data.docname},
+                user=frappe.session.user,
+                doctype="Payment Entry",
+                docname=self.data.docname,
+            )
+            self.remove_payment = True
+
+            payment_entry_doc = frappe.get_doc("Payment Entry", self.data.docname)
+            payment_entry_doc.remarks = ""
+            payment_entry_doc.online_payment_status = "Paid"
+            payment_entry_doc.reference_no = ref_no
+            payment_entry_doc.submit()
+
+            if getattr(self, "bulk_payments", None):
+                send_money_btn = self.get_element(
+                    "//button[normalize-space(text())='Go to Send Money' and contains(@class, 'btn-primary')]",
+                    "xpath",
+                    now=True,
+                )
+                self.br.execute_script("arguments[0].click();", send_money_btn)
+                self.make_payment()
+                return
+            else:
+                self.show_msg("All Payments are completed", self.bulk_payments)
+                js = "setTimeout(()=>{frappe.hide_msgprint(); cur_list.refresh();cur_list.clear_checked_items();},4000);"
+                frappe.publish_realtime(
+                    "eval_js_bulk",
+                    js,
+                    user=frappe.session.user,
+                    doctype=self.doctype,
+                    docname=self.docname,
+                )
+        
         frappe.db.commit()
         self.logout()
 

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -607,6 +607,7 @@ class HDFCBankAPI(BankAPI):
         confirm_btn.click()
         self._handle_post_confirm_payment_state()
 
+    @set_correct_payment_data
     def make_neft_payment(self):
         amt = self.get_element("transfer-amount-input", "id")
         amt.clear()

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -221,9 +221,6 @@ class HDFCBankAPI(BankAPI):
         self.save_for_later()
 
     def process_security_questions(self):
-        bulk = ""
-        if self.bulk_payments is not None:
-            bulk = "_bulk"
         frappe.publish_realtime(
             "get_bank_answers",
             {
@@ -347,7 +344,7 @@ class HDFCBankAPI(BankAPI):
         self.logged_in = 1
 
         if self.doctype == "Bank Integration Settings":
-            self.show_msg("Credentials verified successfully!")
+            self.show_msg("Credentials verified successfully!",self.bulk_payments)
             self.emit_js("setTimeout(() => {frappe.hide_msgprint()}, 2000);")
             self.logout()
         elif self.doctype == "Payment Entry":

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -750,6 +750,7 @@ class HDFCBankAPI(BankAPI):
         payment_entry_doc.online_payment_status = "Paid"
         payment_entry_doc.reference_no = ref_no
         payment_entry_doc.submit()
+        frappe.db.commit()
 
         if self.is_bulk_payments:
             if getattr(self, "bulk_payments", None):
@@ -774,7 +775,6 @@ class HDFCBankAPI(BankAPI):
                     docname=self.docname,
                 )
 
-        frappe.db.commit()
         self.logout()
 
     def fetch_transactions(self, from_date=None):

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -27,7 +27,7 @@ class HDFCBankAPI(BankAPI):
         self.bank_name = "HDFC Bank"
 
     def login(self):
-        self.show_msg("Attempting login...", self.bulk_payments)
+        self.show_msg("Attempting login...", self.is_bulk_payments)
         self.setup_browser()
         self.br.get("https://netbanking.hdfcbank.com/netbanking/")
 
@@ -201,8 +201,10 @@ class HDFCBankAPI(BankAPI):
             except Exception:
                 pass
 
+        # here both listeners for list and form view and kept separate as they require
+        # cur_list and cur_frm respectively
         bulk = ""
-        if self.bulk_payments is not None:
+        if self.is_bulk_payments:
             bulk = "_bulk"
 
         frappe.publish_realtime(
@@ -344,20 +346,12 @@ class HDFCBankAPI(BankAPI):
         self.logged_in = 1
 
         if self.doctype == "Bank Integration Settings":
-            self.show_msg("Credentials verified successfully!",self.bulk_payments)
+            self.show_msg("Credentials verified successfully!", self.bulk_payments)
             self.emit_js("setTimeout(() => {frappe.hide_msgprint()}, 2000);")
             self.logout()
         elif self.doctype == "Payment Entry":
-            if self.bulk_payments:
-                self.show_msg(
-                    "Login Successful! Processing payments..", self.bulk_payments
-                )
-                self.make_payment()
-            else:
-                self.show_msg(
-                    "Login Successful! Processing payment..", self.bulk_payments
-                )
-                self.make_payment()
+            self.show_msg("Login Successful! Processing payment..", self.bulk_payments)
+            self.make_payment()
         elif self.doctype == "Bank Account":
             self.fetch_transactions()
 
@@ -690,22 +684,14 @@ class HDFCBankAPI(BankAPI):
         details_button = self.get_element("showHideBtn", "id")
         details_button.click()
 
-        if self.data.docname:
-            save_file(
-                self.data.docname + " Online Payment Screenshot.png",
-                self.br.get_screenshot_as_png(),
-                self.data.doctype,
-                self.data.docname,
-                is_private=1,
-            )
-        else:
-            save_file(
-                self.docname + " Online Payment Screenshot.png",
-                self.br.get_screenshot_as_png(),
-                self.doctype,
-                self.docname,
-                is_private=1,
-            )
+        save_file(
+            self.data.docname + " Online Payment Screenshot.png",
+            self.br.get_screenshot_as_png(),
+            "Payment Entry",
+            self.data.docname,
+            is_private=1,
+        )
+
         ref_no = "-"
         if self.data.transfer_type == "Transfer within the bank":
             try:
@@ -733,32 +719,39 @@ class HDFCBankAPI(BankAPI):
             except Exception:
                 pass
 
-        if self.bulk_payments is None:
+        # these are kept separate as one requires frm object which is not present in list view
+        if not self.is_bulk_payments:
             frappe.publish_realtime(
                 "payment_success",
-                {"ref_no": ref_no, "uid": self.uid},
-                user=frappe.session.user,
-                doctype="Payment Entry",
-                docname=self.docname,
-            )
-            self.remove_payment = True
-
-        else:
-            frappe.publish_realtime(
-                "payment_success_bulk",
-                {"ref_no": ref_no, "uid": self.uid, "paid_amount": self.data.amount,"docname":self.data.docname},
+                {
+                    "ref_no": ref_no,
+                    "uid": self.uid,
+                },
                 user=frappe.session.user,
                 doctype="Payment Entry",
                 docname=self.data.docname,
             )
-            self.remove_payment = True
+        else:
+            frappe.publish_realtime(
+                "payment_success_bulk",
+                {
+                    "ref_no": ref_no,
+                    "uid": self.uid,
+                    "paid_amount": self.data.amount,
+                    "docname": self.data.docname,
+                },
+                user=frappe.session.user,
+                doctype="Payment Entry",
+                docname=self.data.docname,
+            )
 
-            payment_entry_doc = frappe.get_doc("Payment Entry", self.data.docname)
-            payment_entry_doc.remarks = ""
-            payment_entry_doc.online_payment_status = "Paid"
-            payment_entry_doc.reference_no = ref_no
-            payment_entry_doc.submit()
+        self.remove_payment = True
+        payment_entry_doc = frappe.get_doc("Payment Entry", self.data.docname)
+        payment_entry_doc.online_payment_status = "Paid"
+        payment_entry_doc.reference_no = ref_no
+        payment_entry_doc.submit()
 
+        if self.is_bulk_payments:
             if getattr(self, "bulk_payments", None):
                 send_money_btn = self.get_element(
                     "//button[normalize-space(text())='Go to Send Money' and contains(@class, 'btn-primary')]",
@@ -770,15 +763,17 @@ class HDFCBankAPI(BankAPI):
                 return
             else:
                 self.show_msg("All Payments are completed", self.bulk_payments)
-                js = "setTimeout(()=>{frappe.hide_msgprint(); cur_list.refresh();cur_list.clear_checked_items();},4000);"
+                js = "if(cur_list && cur_list._uid=={0}){setTimeout(()=>{frappe.hide_msgprint(); cur_list.refresh();cur_list.clear_checked_items();},4000);}".format(
+                    self.uid
+                )
                 frappe.publish_realtime(
-                    "eval_js_bulk",
+                    "eval_js",
                     js,
                     user=frappe.session.user,
                     doctype=self.doctype,
                     docname=self.docname,
                 )
-        
+
         frappe.db.commit()
         self.logout()
 

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -755,6 +755,7 @@ class HDFCBankAPI(BankAPI):
                     "uid": self.uid,
                     "paid_amount": self.data.amount,
                     "docname": self.data.docname,
+                    "party_name":self.data.party_name,
                     "action": "payment_success_bulk",
                 },
                 user=frappe.session.user,

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -757,6 +757,7 @@ class HDFCBankAPI(BankAPI):
                     "//button[normalize-space(text())='Go to Send Money' and contains(@class, 'btn-primary')]",
                     "xpath",
                     now=True,
+                    throw="ignore"
                 )
                 if send_money_btn:
                     self.br.execute_script("arguments[0].click();", send_money_btn)

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -766,7 +766,7 @@ class HDFCBankAPI(BankAPI):
                 return
             else:
                 self.show_msg("All Payments are completed")
-                js = f"if (cur_list && cur_list._uid === '{self.uid}') setTimeout(() => {{ frappe.hide_msgprint(); cur_list.refresh(); cur_list.clear_checked_items(); }}, 4000);"
+                js = "if(cur_list && cur_list._uid=='{0}'){{setTimeout(()=>{{frappe.hide_msgprint(); cur_list.refresh();cur_list.clear_checked_items();}},4000);}}".format(self.uid)
                 frappe.publish_realtime(
                     "eval_js",
                     js,

--- a/bank_integration/bank_integration/api/hdfc_bank_api.py
+++ b/bank_integration/bank_integration/api/hdfc_bank_api.py
@@ -763,7 +763,7 @@ class HDFCBankAPI(BankAPI):
                 return
             else:
                 self.show_msg("All Payments are completed", self.bulk_payments)
-                js = "if(cur_list && cur_list._uid=={0}){setTimeout(()=>{frappe.hide_msgprint(); cur_list.refresh();cur_list.clear_checked_items();},4000);}".format(
+                js = "if(cur_list && cur_list._uid=='{0}'){setTimeout(()=>{frappe.hide_msgprint(); cur_list.refresh();cur_list.clear_checked_items();},4000);}".format(
                     self.uid
                 )
                 frappe.publish_realtime(

--- a/bank_integration/bank_integration/api/payments.py
+++ b/bank_integration/bank_integration/api/payments.py
@@ -8,29 +8,50 @@ import json
 import frappe
 from bank_integration.bank_integration.api import get_bank_api
 
+
 @frappe.whitelist()
 def make_payment(docname, uid, data):
     data = frappe._dict(json.loads(data))
 
-    bi_name = frappe.db.get_value('Bank Account', {'account': data.from_account}, 'name')
-    bi = frappe.get_doc('Bank Integration Settings', bi_name)
+    bi_name = frappe.db.get_value(
+        "Bank Account", {"account": data.from_account}, "name"
+    )
+    bi = frappe.get_doc("Bank Integration Settings", bi_name)
     data.from_account = bi.bank_account_no
+    data.docname = docname
 
-    bank = get_bank_api(bi.bank_name, bi.username, bi.get_password(), doctype="Payment Entry", docname=docname,
-        uid=uid, data=data)
+    bank = get_bank_api(
+        bi.bank_name,
+        bi.username,
+        bi.get_password(),
+        doctype="Payment Entry",
+        docname=docname,
+        uid=uid,
+        data=data,
+    )
 
+
+# bulk payments will use only one bank integration settings containing id, password and account no.
+# therefore all the payments will be made using those settings
 @frappe.whitelist()
-def make_bulk_payment(data):
-    bulk_data=json.loads(data)
-    data_converted_to_frappe_dict=[]
+def make_bulk_payment(data, uid):
+    bulk_data = json.loads(data)
+    data_converted_to_frappe_dict = []
     for d in bulk_data:
-        frappe_dict_d = frappe._dict(d)
-        frappe_dict_data=frappe._dict(frappe_dict_d.data)
+        frappe_dict_data = frappe._dict(d["data"])
 
-        bi_name = frappe.db.get_value('Bank Account', {'account': frappe_dict_data.from_account}, 'name')
-        bi = frappe.get_doc('Bank Integration Settings', bi_name)
+        bi_name = frappe.db.get_value(
+            "Bank Account", {"account": frappe_dict_data.from_account}, "name"
+        )
+        bi = frappe.get_doc("Bank Integration Settings", bi_name)
         frappe_dict_data.from_account = bi.bank_account_no
         data_converted_to_frappe_dict.append(frappe_dict_data)
-    # not using changed data
-    bank = get_bank_api(bi.bank_name, bi.username, bi.get_password(), doctype="Payment Entry", 
-         bulk_payments=data_converted_to_frappe_dict)
+
+    bank = get_bank_api(
+        bi.bank_name,
+        bi.username,
+        bi.get_password(),
+        doctype="Payment Entry",
+        uid=uid,
+        bulk_payments=data_converted_to_frappe_dict,
+    )

--- a/bank_integration/bank_integration/api/payments.py
+++ b/bank_integration/bank_integration/api/payments.py
@@ -61,6 +61,10 @@ def make_payment(docname, uid):
 def make_bulk_payment(docname_list, uid):
 
     docname_list = json.loads(docname_list)
+
+    if docname_list == []:
+        frappe.throw("No payments selected for bulk processing")
+
     data_converted_to_frappe_dict = []
 
     for docname in docname_list:

--- a/bank_integration/bank_integration/api/payments.py
+++ b/bank_integration/bank_integration/api/payments.py
@@ -10,8 +10,19 @@ from bank_integration.bank_integration.api import get_bank_api
 
 
 @frappe.whitelist()
-def make_payment(docname, uid, data):
-    data = frappe._dict(json.loads(data))
+def make_payment(docname, uid):
+
+    payment_entry = frappe.get_doc("Payment Entry", docname)
+    data = frappe._dict(
+        {
+            "from_account": payment_entry.paid_from,
+            "to_account": payment_entry.party_bank_ac_no,
+            "transfer_type": payment_entry.transfer_type,
+            "amount": payment_entry.paid_amount,
+            "payment_desc": payment_entry.payment_desc,
+            "docname": docname,
+        }
+    )
 
     bi_name = frappe.db.get_value(
         "Bank Account", {"account": data.from_account}, "name"
@@ -23,8 +34,15 @@ def make_payment(docname, uid, data):
             )
         )
     bi = frappe.get_doc("Bank Integration Settings", bi_name)
+
+    if bi.disabled:
+        frappe.throw(
+            "Bank Integration Settings for bank account {} is disabled".format(
+                data.from_account
+            )
+        )
+
     data.from_account = bi.bank_account_no
-    data.docname = docname
 
     bank = get_bank_api(
         bi.bank_name,
@@ -40,13 +58,28 @@ def make_payment(docname, uid, data):
 # bulk payments will use only one bank integration settings containing id, password and account no.
 # therefore all the payments will be made using those settings
 @frappe.whitelist()
-def make_bulk_payment(data, uid):
-    bulk_data = json.loads(data)
-    data_converted_to_frappe_dict = []
-    bank_account_no = []
-    for d in bulk_data:
-        frappe_dict_data = frappe._dict(d["data"])
+def make_bulk_payment(docname_list, uid):
 
+    docname_list = json.loads(docname_list)
+    data_converted_to_frappe_dict = []
+
+    for docname in docname_list:
+        payment_entry = frappe.get_doc("Payment Entry", docname)
+        data = frappe._dict(
+            {
+                "from_account": payment_entry.paid_from,
+                "to_account": payment_entry.party_bank_ac_no,
+                "transfer_type": payment_entry.transfer_type,
+                "amount": payment_entry.paid_amount,
+                "payment_desc": payment_entry.payment_desc,
+                "docname": docname,
+                "doctype": "Payment Entry",
+            }
+        )
+        data_converted_to_frappe_dict.append(data)
+
+    bank_account_no = []
+    for frappe_dict_data in data_converted_to_frappe_dict:
         bi_name = frappe.db.get_value(
             "Bank Account", {"account": frappe_dict_data.from_account}, "name"
         )
@@ -57,9 +90,16 @@ def make_bulk_payment(data, uid):
                 )
             )
         bi = frappe.get_doc("Bank Integration Settings", bi_name)
+
+        if bi.disabled:
+            frappe.throw(
+                "Bank Integration Settings for bank account {} is disabled".format(
+                    frappe_dict_data.from_account
+                )
+            )
+
         frappe_dict_data.from_account = bi.bank_account_no
         bank_account_no.append(bi.bank_account_no)
-        data_converted_to_frappe_dict.append(frappe_dict_data)
 
     if len(set(bank_account_no)) > 1:
         frappe.throw(

--- a/bank_integration/bank_integration/api/payments.py
+++ b/bank_integration/bank_integration/api/payments.py
@@ -18,3 +18,19 @@ def make_payment(docname, uid, data):
 
     bank = get_bank_api(bi.bank_name, bi.username, bi.get_password(), doctype="Payment Entry", docname=docname,
         uid=uid, data=data)
+
+@frappe.whitelist()
+def make_bulk_payment(data):
+    bulk_data=json.loads(data)
+    data_converted_to_frappe_dict=[]
+    for d in bulk_data:
+        frappe_dict_d = frappe._dict(d)
+        frappe_dict_data=frappe._dict(frappe_dict_d.data)
+
+        bi_name = frappe.db.get_value('Bank Account', {'account': frappe_dict_data.from_account}, 'name')
+        bi = frappe.get_doc('Bank Integration Settings', bi_name)
+        frappe_dict_data.from_account = bi.bank_account_no
+        data_converted_to_frappe_dict.append(frappe_dict_data)
+    # not using changed data
+    bank = get_bank_api(bi.bank_name, bi.username, bi.get_password(), doctype="Payment Entry", 
+         bulk_payments=data_converted_to_frappe_dict)

--- a/bank_integration/bank_integration/api/payments.py
+++ b/bank_integration/bank_integration/api/payments.py
@@ -113,6 +113,7 @@ def make_bulk_payment(docname_list, uid):
         doctype="Payment Entry",
         uid=uid,
         bulk_payments=data_converted_to_frappe_dict,
+        docname=data_converted_to_frappe_dict[0].docname,
     )
 
 

--- a/bank_integration/bank_integration/api/payments.py
+++ b/bank_integration/bank_integration/api/payments.py
@@ -63,7 +63,7 @@ def make_bulk_payment(docname_list, uid):
     docname_list = json.loads(docname_list)
     data_converted_to_frappe_dict = []
 
-    if docname_list and len(docname_list) == 0:
+    if docname_list == []:
         frappe.throw("No payments selected for bulk payment processing")
 
     for docname in docname_list:

--- a/bank_integration/bank_integration/api/payments.py
+++ b/bank_integration/bank_integration/api/payments.py
@@ -16,6 +16,12 @@ def make_payment(docname, uid, data):
     bi_name = frappe.db.get_value(
         "Bank Account", {"account": data.from_account}, "name"
     )
+    if not frappe.db.exists("Bank Integration Settings", bi_name):
+        frappe.throw(
+            "No Bank Integration Settings found for bank account {}".format(
+                data.from_account
+            )
+        )
     bi = frappe.get_doc("Bank Integration Settings", bi_name)
     data.from_account = bi.bank_account_no
     data.docname = docname
@@ -37,15 +43,28 @@ def make_payment(docname, uid, data):
 def make_bulk_payment(data, uid):
     bulk_data = json.loads(data)
     data_converted_to_frappe_dict = []
+    bank_account_no = []
     for d in bulk_data:
         frappe_dict_data = frappe._dict(d["data"])
 
         bi_name = frappe.db.get_value(
             "Bank Account", {"account": frappe_dict_data.from_account}, "name"
         )
+        if not frappe.db.exists("Bank Integration Settings", bi_name):
+            frappe.throw(
+                "No Bank Integration Settings found for bank account {}".format(
+                    frappe_dict_data.from_account
+                )
+            )
         bi = frappe.get_doc("Bank Integration Settings", bi_name)
         frappe_dict_data.from_account = bi.bank_account_no
+        bank_account_no.append(bi.bank_account_no)
         data_converted_to_frappe_dict.append(frappe_dict_data)
+
+    if len(set(bank_account_no)) > 1:
+        frappe.throw(
+            "All payments should have same bank account for bulk payment processing"
+        )
 
     bank = get_bank_api(
         bi.bank_name,
@@ -55,3 +74,6 @@ def make_bulk_payment(data, uid):
         uid=uid,
         bulk_payments=data_converted_to_frappe_dict,
     )
+
+
+# validate or support multiple bi

--- a/bank_integration/bank_integration/api/payments.py
+++ b/bank_integration/bank_integration/api/payments.py
@@ -8,6 +8,25 @@ import json
 import frappe
 from bank_integration.bank_integration.api import get_bank_api
 
+def get_bank_integration_settings(from_account):
+    bi_name = frappe.db.get_value(
+        "Bank Account", {"account": from_account}, "name"
+    )
+    if not frappe.db.exists("Bank Integration Settings", bi_name):
+        frappe.throw(
+            "No Bank Integration Settings found for bank account {}".format(
+                from_account
+            )
+        )
+    bi = frappe.get_doc("Bank Integration Settings", bi_name)
+
+    if bi.disabled:
+        frappe.throw(
+            "Bank Integration Settings for bank account {} is disabled".format(
+                from_account
+            )
+        )
+    return bi
 
 @frappe.whitelist()
 def make_payment(docname, uid):
@@ -24,23 +43,9 @@ def make_payment(docname, uid):
         }
     )
 
-    bi_name = frappe.db.get_value(
-        "Bank Account", {"account": data.from_account}, "name"
-    )
-    if not frappe.db.exists("Bank Integration Settings", bi_name):
-        frappe.throw(
-            "No Bank Integration Settings found for bank account {}".format(
-                data.from_account
-            )
-        )
-    bi = frappe.get_doc("Bank Integration Settings", bi_name)
+    bi=get_bank_integration_settings(data.from_account)
 
-    if bi.disabled:
-        frappe.throw(
-            "Bank Integration Settings for bank account {} is disabled".format(
-                data.from_account
-            )
-        )
+    
 
     data.from_account = bi.bank_account_no
 
@@ -67,9 +72,6 @@ def make_bulk_payment(docname_list, uid):
 
     data_converted_to_frappe_dict = []
 
-    if docname_list == []:
-        frappe.throw("No payments selected for bulk payment processing")
-
     for docname in docname_list:
         payment_entry = frappe.get_doc("Payment Entry", docname)
         data = frappe._dict(
@@ -87,23 +89,7 @@ def make_bulk_payment(docname_list, uid):
 
     bank_account_no = []
     for frappe_dict_data in data_converted_to_frappe_dict:
-        bi_name = frappe.db.get_value(
-            "Bank Account", {"account": frappe_dict_data.from_account}, "name"
-        )
-        if not frappe.db.exists("Bank Integration Settings", bi_name):
-            frappe.throw(
-                "No Bank Integration Settings found for bank account {}".format(
-                    frappe_dict_data.from_account
-                )
-            )
-        bi = frappe.get_doc("Bank Integration Settings", bi_name)
-
-        if bi.disabled:
-            frappe.throw(
-                "Bank Integration Settings for bank account {} is disabled".format(
-                    frappe_dict_data.from_account
-                )
-            )
+        bi=get_bank_integration_settings(frappe_dict_data.from_account)
 
         frappe_dict_data.from_account = bi.bank_account_no
         bank_account_no.append(bi.bank_account_no)
@@ -122,6 +108,3 @@ def make_bulk_payment(docname_list, uid):
         bulk_payments=data_converted_to_frappe_dict,
         docname=data_converted_to_frappe_dict[0].docname,
     )
-
-
-# validate or support multiple bi

--- a/bank_integration/bank_integration/api/payments.py
+++ b/bank_integration/bank_integration/api/payments.py
@@ -70,6 +70,9 @@ def make_bulk_payment(docname_list, uid):
     if docname_list == []:
         frappe.throw("No payments selected for bulk processing")
 
+    if len(docname_list) >500:
+        frappe.throw("You can process maximum 500 payments at a time")
+
     data_converted_to_frappe_dict = []
 
     for docname in docname_list:

--- a/bank_integration/bank_integration/api/payments.py
+++ b/bank_integration/bank_integration/api/payments.py
@@ -80,6 +80,7 @@ def make_bulk_payment(docname_list, uid):
         data = frappe._dict(
             {
                 "from_account": payment_entry.paid_from,
+                "party_name": payment_entry.party_name,
                 "to_account": payment_entry.party_bank_ac_no,
                 "transfer_type": payment_entry.transfer_type,
                 "amount": payment_entry.paid_amount,

--- a/bank_integration/bank_integration/api/payments.py
+++ b/bank_integration/bank_integration/api/payments.py
@@ -63,6 +63,9 @@ def make_bulk_payment(docname_list, uid):
     docname_list = json.loads(docname_list)
     data_converted_to_frappe_dict = []
 
+    if docname_list and len(docname_list) == 0:
+        frappe.throw("No payments selected for bulk payment processing")
+
     for docname in docname_list:
         payment_entry = frappe.get_doc("Payment Entry", docname)
         data = frappe._dict(

--- a/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.js
+++ b/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.js
@@ -12,7 +12,10 @@ frappe.ui.form.on('Bank Integration Settings', {
 		bi.listenForQuestions(frm);
 	},
 	async validate(frm) {
-
+		let n=1
+		if(frm.docname.includes("new-bank-integration-settings")){
+			n=0
+		}
 		frm._uid = frappe.utils.get_random(7);
 		let bank_integrations = await frappe.db.get_list(
 			"Bank Integration Settings",
@@ -21,7 +24,7 @@ frappe.ui.form.on('Bank Integration Settings', {
 				filters: { bank_account: frm.doc.bank_account }
 			}
 		);
-		if (bank_integrations.length > 0) {
+		if (bank_integrations.length > n) {
 			frappe.throw(__("Only one Bank Integration for a bank account can exist."));
 		}
 		frm.call("check_credentials", { uid: frm._uid });

--- a/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.js
+++ b/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.js
@@ -3,8 +3,29 @@
 
 frappe.ui.form.on('Bank Integration Settings', {
 	setup(frm) {
-		frappe.realtime.on("eval_js", function(message){
-			eval(message);
+		frappe.realtime.on("bi_action", function(data){
+			switch(data.action){
+				case "show_message":
+                    if(frm && frm._uid == data.uid){
+                        frappe.update_msgprint(data.message);
+                    }
+                    break;
+				case "login_success":
+					if(frm._uid == data.uid){
+						setTimeout(() => {
+							frappe.hide_msgprint();
+						}, 2000);
+					}
+					break;
+				case "reload_doc":
+                    if(frm && frm._uid == data.uid){
+                        if (frm.docname == data.docname) {
+							frappe.hide_msgprint()
+                            frm.reload_doc();
+                        }
+                    }
+                    break;
+			}
 		});
 	},
 	onload(frm) {

--- a/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.js
+++ b/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.js
@@ -21,8 +21,10 @@ frappe.ui.form.on('Bank Integration Settings', {
 			}
 		);
 		if (bank_integrations.length > 0) {
-			frm.reload_doc();
-			frappe.throw(__("Only one Bank Integration for a bank account can exist."));
+			if (bank_integrations[0].name !== frm.doc.name) {
+				frm.reload_doc();
+				frappe.throw(__("Only one Bank Integration for a bank account can exist."));
+			}
 		}
 		if(!frm.doc.disabled){
 			frm.call("check_credentials", { uid: frm._uid });

--- a/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.js
+++ b/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.js
@@ -12,21 +12,20 @@ frappe.ui.form.on('Bank Integration Settings', {
 		bi.listenForQuestions(frm);
 	},
 	async validate(frm) {
-		let n=1
-		if(frm.docname.includes("new-bank-integration-settings")){
-			n=0
-		}
 		frm._uid = frappe.utils.get_random(7);
 		let bank_integrations = await frappe.db.get_list(
 			"Bank Integration Settings",
 			{
 				fields: ["name"],
-				filters: { bank_account: frm.doc.bank_account }
+				filters: { bank_account_no: frm.doc.bank_account_no }
 			}
 		);
-		if (bank_integrations.length > n) {
+		if (bank_integrations.length > 0) {
+			frm.reload_doc();
 			frappe.throw(__("Only one Bank Integration for a bank account can exist."));
 		}
-		frm.call("check_credentials", { uid: frm._uid });
+		if(!frm.doc.disabled){
+			frm.call("check_credentials", { uid: frm._uid });
+		}
 	}
 });

--- a/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.js
+++ b/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.js
@@ -49,6 +49,8 @@ frappe.ui.form.on('Bank Integration Settings', {
 		if (bank_integrations.length > n) {
 			frappe.throw(__("Only one Bank Integration for a bank account can exist."));
 		}
-		frm.call("check_credentials", { uid: frm._uid });
+		if(!frm.doc.disabled){
+			frm.call("check_credentials", { uid: frm._uid });
+		}
 	}
 });

--- a/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.js
+++ b/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.js
@@ -11,9 +11,19 @@ frappe.ui.form.on('Bank Integration Settings', {
 		bi.listenForOtp(frm);
 		bi.listenForQuestions(frm);
 	},
-	validate(frm) {
-		if (frm.doc.disabled) return;
+	async validate(frm) {
+
 		frm._uid = frappe.utils.get_random(7);
-		frm.call('check_credentials', {uid: frm._uid});
+		let bank_integrations = await frappe.db.get_list(
+			"Bank Integration Settings",
+			{
+				fields: ["name"],
+				filters: { bank_account: frm.doc.bank_account }
+			}
+		);
+		if (bank_integrations.length > 0) {
+			frappe.throw(__("Only one Bank Integration for a bank account can exist."));
+		}
+		frm.call("check_credentials", { uid: frm._uid });
 	}
 });

--- a/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.js
+++ b/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.js
@@ -11,13 +11,14 @@ frappe.ui.form.on('Bank Integration Settings', {
                     }
                     break;
 				case "login_success":
-					if(frm._uid == data.uid){
+					if(frm && frm._uid == data.uid){
 						setTimeout(() => {
 							frappe.hide_msgprint();
 						}, 2000);
 					}
 					break;
 				case "reload_doc":
+					
                     if(frm && frm._uid == data.uid){
                         if (frm.docname == data.docname) {
 							frappe.hide_msgprint()

--- a/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.js
+++ b/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.js
@@ -17,7 +17,10 @@ frappe.ui.form.on('Bank Integration Settings', {
 			"Bank Integration Settings",
 			{
 				fields: ["name"],
-				filters: { bank_account_no: frm.doc.bank_account_no }
+				filters: {
+            		bank_account_no: frm.doc.bank_account_no,
+            		name: ["!=", frm.doc.name],
+        		}
 			}
 		);
 		if (bank_integrations.length > 0) {

--- a/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.py
+++ b/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.py
@@ -15,7 +15,7 @@ class BankIntegrationSettings(Document):
 		bank_integrations=frappe.db.get_list(
 			'Bank Integration Settings',
 			fields=['name'],
-			filters={'name':self.name
+			filters={'bank_account':self.bank_account
 			})
 		if len(bank_integrations) > n:
 			frappe.throw('Only one Bank Integration for a bank account can exist.')

--- a/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.py
+++ b/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.py
@@ -15,7 +15,8 @@ class BankIntegrationSettings(Document):
 			filters={'bank_account_no':self.bank_account_no
 			})
 		if len(bank_integrations) > 0:
-			frappe.throw('Only one Bank Integration for a bank account can exist.')
+			if bank_integrations[0].name != self.name:
+				frappe.throw('Only one Bank Integration for a bank account can exist.')
 
 	@frappe.whitelist()
 	def check_credentials(self, uid):

--- a/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.py
+++ b/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.py
@@ -9,15 +9,12 @@ from bank_integration.bank_integration.api import get_bank_api
 
 class BankIntegrationSettings(Document):
 	def before_save(self):
-		n=1
-		if self.is_new():
-			n=0
 		bank_integrations=frappe.db.get_list(
 			'Bank Integration Settings',
 			fields=['name'],
-			filters={'bank_account':self.bank_account
+			filters={'bank_account_no':self.bank_account_no
 			})
-		if len(bank_integrations) > n:
+		if len(bank_integrations) > 0:
 			frappe.throw('Only one Bank Integration for a bank account can exist.')
 
 	@frappe.whitelist()

--- a/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.py
+++ b/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.py
@@ -9,14 +9,16 @@ from bank_integration.bank_integration.api import get_bank_api
 
 class BankIntegrationSettings(Document):
 	def before_save(self):
+		filters = {"bank_account_no": self.bank_account_no}
+		if not self.is_new():
+			filters["name"] = ["!=", self.name]
 		bank_integrations=frappe.db.get_list(
 			'Bank Integration Settings',
 			fields=['name'],
-			filters={'bank_account_no':self.bank_account_no
-			})
+			filters=filters
+			)
 		if len(bank_integrations) > 0:
-			if bank_integrations[0].name != self.name:
-				frappe.throw('Only one Bank Integration for a bank account can exist.')
+			frappe.throw('Only one Bank Integration for a bank account can exist.')
 
 	@frappe.whitelist()
 	def check_credentials(self, uid):

--- a/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.py
+++ b/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.py
@@ -9,12 +9,15 @@ from bank_integration.bank_integration.api import get_bank_api
 
 class BankIntegrationSettings(Document):
 	def before_save(self):
+		n=1
+		if self.is_new():
+			n=0
 		bank_integrations=frappe.db.get_list(
 			'Bank Integration Settings',
 			fields=['name'],
 			filters={'name':self.name
 			})
-		if len(bank_integrations) > 0:
+		if len(bank_integrations) > n:
 			frappe.throw('Only one Bank Integration for a bank account can exist.')
 
 	@frappe.whitelist()

--- a/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.py
+++ b/bank_integration/bank_integration/doctype/bank_integration_settings/bank_integration_settings.py
@@ -8,6 +8,15 @@ from frappe.model.document import Document
 from bank_integration.bank_integration.api import get_bank_api
 
 class BankIntegrationSettings(Document):
+	def before_save(self):
+		bank_integrations=frappe.db.get_list(
+			'Bank Integration Settings',
+			fields=['name'],
+			filters={'name':self.name
+			})
+		if len(bank_integrations) > 0:
+			frappe.throw('Only one Bank Integration for a bank account can exist.')
+
 	@frappe.whitelist()
 	def check_credentials(self, uid):
 		if self.disabled:

--- a/bank_integration/hooks.py
+++ b/bank_integration/hooks.py
@@ -20,6 +20,10 @@ doctype_js = {
     "Bank Reconciliation Tool": "scripts/bank_reconciliation_tool.js"
 }
 
+doctype_list_js = {
+    "Payment Entry": "scripts/payment_entry_list.js",
+}
+
 page_js = {
     "bank-reconciliation": "scripts/bank_reconciliation.js",
 }

--- a/bank_integration/install.py
+++ b/bank_integration/install.py
@@ -204,6 +204,7 @@ custom_fields = {
                 && doc.transfer_type=='Transfer to other bank (NEFT)')",
             'insert_after': 'transfer_type',
             'print_hide': 1,
+            'in_list_view':1,
             'permlevel': 7
         },
         {
@@ -215,6 +216,7 @@ custom_fields = {
                 && doc.comm_type=='Email')",
             'insert_after': 'comm_type',
             'print_hide': 1,
+            'in_list_view':1,
             'permlevel': 7
         },
         {
@@ -226,6 +228,7 @@ custom_fields = {
                 && doc.comm_type=='Mobile')",
             'insert_after': 'comm_email',
             'print_hide': 1,
+            'in_list_view':1,
             'permlevel': 7
         },
         {

--- a/bank_integration/install.py
+++ b/bank_integration/install.py
@@ -133,7 +133,6 @@ custom_fields = {
                 && doc.party)",
             'insert_after': 'bank_payment_section',
             'print_hide': 1,
-            'in_list_view':1,
             'permlevel': 7
         },
         {
@@ -144,7 +143,6 @@ custom_fields = {
             'depends_on': "eval:doc.pay_now",
             'insert_after': 'pay_now',
             'print_hide': 1,
-            'in_list_view':1,
             'permlevel': 7
         },
         {
@@ -154,7 +152,6 @@ custom_fields = {
             'depends_on': "eval:doc.pay_now",
             'insert_after': 'party_bank',
             'print_hide': 1,
-            'in_list_view':1,
             'permlevel': 7
         },
         {
@@ -165,7 +162,6 @@ custom_fields = {
             'depends_on': "eval:(doc.pay_now && doc.creation)",
             'insert_after': 'party_bank_ac_no',
             'print_hide': 1,
-            'in_list_view':1,
             'read_only': 1,
             'permlevel': 7
         },
@@ -181,7 +177,6 @@ custom_fields = {
             'depends_on': "eval:doc.pay_now",
             'insert_after': 'bank_payment_cb',
             'print_hide': 1,
-            'in_list_view':1,
             'permlevel': 7
         },
         {
@@ -192,7 +187,6 @@ custom_fields = {
             'depends_on': "eval:doc.pay_now",
             'insert_after': 'payment_desc',
             'print_hide': 1,
-            'in_list_view':1,
             'permlevel': 7
         },
         {
@@ -204,7 +198,6 @@ custom_fields = {
                 && doc.transfer_type=='Transfer to other bank (NEFT)')",
             'insert_after': 'transfer_type',
             'print_hide': 1,
-            'in_list_view':1,
             'permlevel': 7
         },
         {
@@ -216,7 +209,6 @@ custom_fields = {
                 && doc.comm_type=='Email')",
             'insert_after': 'comm_type',
             'print_hide': 1,
-            'in_list_view':1,
             'permlevel': 7
         },
         {
@@ -228,7 +220,6 @@ custom_fields = {
                 && doc.comm_type=='Mobile')",
             'insert_after': 'comm_email',
             'print_hide': 1,
-            'in_list_view':1,
             'permlevel': 7
         },
         {

--- a/bank_integration/install.py
+++ b/bank_integration/install.py
@@ -133,6 +133,7 @@ custom_fields = {
                 && doc.party)",
             'insert_after': 'bank_payment_section',
             'print_hide': 1,
+            'in_list_view':1,
             'permlevel': 7
         },
         {
@@ -143,6 +144,7 @@ custom_fields = {
             'depends_on': "eval:doc.pay_now",
             'insert_after': 'pay_now',
             'print_hide': 1,
+            'in_list_view':1,
             'permlevel': 7
         },
         {
@@ -152,6 +154,7 @@ custom_fields = {
             'depends_on': "eval:doc.pay_now",
             'insert_after': 'party_bank',
             'print_hide': 1,
+            'in_list_view':1,
             'permlevel': 7
         },
         {
@@ -162,6 +165,7 @@ custom_fields = {
             'depends_on': "eval:(doc.pay_now && doc.creation)",
             'insert_after': 'party_bank_ac_no',
             'print_hide': 1,
+            'in_list_view':1,
             'read_only': 1,
             'permlevel': 7
         },
@@ -177,6 +181,7 @@ custom_fields = {
             'depends_on': "eval:doc.pay_now",
             'insert_after': 'bank_payment_cb',
             'print_hide': 1,
+            'in_list_view':1,
             'permlevel': 7
         },
         {
@@ -187,6 +192,7 @@ custom_fields = {
             'depends_on': "eval:doc.pay_now",
             'insert_after': 'payment_desc',
             'print_hide': 1,
+            'in_list_view':1,
             'permlevel': 7
         },
         {

--- a/bank_integration/patches.txt
+++ b/bank_integration/patches.txt
@@ -1,1 +1,1 @@
-execute:from bank_integration.install import after_install; after_install() # 2
+execute:from bank_integration.install import after_install; after_install() # 18

--- a/bank_integration/public/js/common.js
+++ b/bank_integration/public/js/common.js
@@ -1,9 +1,14 @@
 frappe.provide('bi');
 frappe.provide("modifyMethod");
 
-bi.listenForOtp = function (frm) {
-	frappe.realtime.on("get_bank_otp", function(data){
-		if (!frm || data.uid != frm._uid || frm.otp_requested) return;
+bi.listenForOtp = function (frm,is_bulk=false) {
+	let bulk=""
+	if(!frm?.docname){
+		bulk="_bulk"
+	}
+	frappe.realtime.on("get_bank_otp"+bulk, function(data){
+
+		if (!is_bulk && (!frm || data.uid != frm._uid || frm.otp_requested)) return;
 
 		frm.otp_requested = true;
 		frappe.hide_msgprint();
@@ -23,8 +28,8 @@ bi.listenForOtp = function (frm) {
 					otp: _data.otp,
 					bank_name: data.bank_name,
 					uid: data.uid,
-					doctype: frm.doc.doctype,
-					docname: frm.doc.name,
+					doctype: frm?.doc?.doctype || frm?.doctype,
+					docname: frm?.doc?.name || null,
 					logged_in: data.logged_in},
 			});
 			frappe.msgprint("Verifying OTP!!")

--- a/bank_integration/public/js/common.js
+++ b/bank_integration/public/js/common.js
@@ -3,7 +3,7 @@ frappe.provide("modifyMethod");
 
 bi.listenForOtp = function (frm,is_bulk=false) {
 	let bulk=""
-	if(!frm?.docname){
+	if(is_bulk){
 		bulk="_bulk"
 	}
 	frappe.realtime.on("get_bank_otp" + bulk, function(data){

--- a/bank_integration/public/js/common.js
+++ b/bank_integration/public/js/common.js
@@ -2,6 +2,8 @@ frappe.provide('bi');
 frappe.provide("modifyMethod");
 
 bi.listenForOtp = function (frm,is_bulk=false) {
+	// frm will contain listview object if it is bulk_payment, 
+	// otherwise it will contain form object. 
 	let bulk=""
 	if(is_bulk){
 		bulk="_bulk"

--- a/bank_integration/public/js/common.js
+++ b/bank_integration/public/js/common.js
@@ -6,7 +6,7 @@ bi.listenForOtp = function (frm,is_bulk=false) {
 	if(!frm?.docname){
 		bulk="_bulk"
 	}
-	frappe.realtime.on("get_bank_otp"+bulk, function(data){
+	frappe.realtime.on("get_bank_otp" + bulk, function(data){
 
 		if (!is_bulk && (!frm || data.uid != frm._uid || frm.otp_requested)) return;
 

--- a/bank_integration/public/js/common.js
+++ b/bank_integration/public/js/common.js
@@ -8,7 +8,7 @@ bi.listenForOtp = function (frm,is_bulk=false) {
 	}
 	frappe.realtime.on("get_bank_otp" + bulk, function(data){
 
-		if (!is_bulk && (!frm || data.uid != frm._uid || frm.otp_requested)) return;
+		if (!frm || data.uid != frm._uid || frm.otp_requested) return;
 
 		frm.otp_requested = true;
 		frappe.hide_msgprint();

--- a/bank_integration/scripts/payment_entry.js
+++ b/bank_integration/scripts/payment_entry.js
@@ -1,14 +1,12 @@
 // Copyright (c) 2018, Resilient Tech and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('Payment Entry', {
-    setup: function(frm) {
-        frappe.realtime.on("eval_js", function(message){
-            eval(message);
-        })
+frappe.ui.form.on("Payment Entry", {
+    setup: function (frm) {
+        // Realtime listener handled via list view only now.
     },
 
-	onload: function(frm) {
+    onload: function (frm) {
         bi.listenForOtp(frm);
         bi.listenForQuestions(frm);
 
@@ -23,67 +21,57 @@ frappe.ui.form.on('Payment Entry', {
             return false;
         });
 
-        frappe.realtime.on('payment_success', function(data){
+        frappe.realtime.on("payment_success", function (data) {
             if (data.uid != frm._uid || frm.success_action_started) {
                 return;
             }
 
             frm.success_action_started = true;
-            frappe.update_msgprint('Payment successful!');
-            setTimeout(function() {
+            frappe.update_msgprint("Payment successful!");
+            setTimeout(function () {
                 frappe.hide_msgprint();
-                frm.set_value('remarks', '');
-                frm.set_value('online_payment_status', 'Paid');
-                frm.set_value('reference_no',data.ref_no);
                 frm.refresh();
-                frm.save().then(function(){
-                    frm.savesubmit().then(() => {
-                        if (frm.doc.comm_email) {
-                            let email_dialog = new frappe.views.CommunicationComposer({
-                                doc: frm.doc,
-                                frm: frm,
-                                subject: `Online Payment Processed (${frm.doc.name})`,
-                                recipients: frm.doc.comm_email,
-                                attach_document_print: true,
-                                message: `Hello,<br><br>
+                if (frm.doc.comm_email) {
+                    let email_dialog = new frappe.views.CommunicationComposer({
+                        doc: frm.doc,
+                        frm: frm,
+                        subject: `Online Payment Processed (${frm.doc.name})`,
+                        recipients: frm.doc.comm_email,
+                        attach_document_print: true,
+                        message: `Hello,<br><br>
                                 A payment for ${fmt_money(frm.doc.paid_amount)} with Reference No. ${frm.doc.reference_no} has been made to your account on ${frappe.datetime.get_today()}. Enclosed is the payment note, with details of your invoices against which the said payment is made.<br><br>
                                 Feel free to get in touch with us if you have any queries or concerns.<br><br>
-                                Thank you for doing business with us. We look forward to your continued patronage in the future.<br><br>`
-                            });
+                                Thank you for doing business with us. We look forward to your continued patronage in the future.<br><br>`,
+                    });
 
-                            email_dialog.dialog.$wrapper.on('shown.bs.modal', () => {
-                                email_dialog.select_attachments();
-                            });
-                        } else {
-                            setup_sms(frm);
-                            if (frm.sms_link) frm.sms_link.click();
-                        }
-                    })
-                });
+                } else {
+                    setup_sms(frm);
+                    if (frm.sms_link) frm.sms_link.click();
+                }
             }, 1000);
             delete frm.success_action_started;
         });
     },
 
-    payment_type: function(frm){
+    payment_type: function (frm) {
         check_bank_integration(frm);
     },
 
-    paid_from: function(frm) {
+    paid_from: function (frm) {
         check_bank_integration(frm);
     },
 
-    party: function(frm) {
+    party: function (frm) {
         set_bank_name_and_ac(frm);
         get_contact_data(frm);
     },
 
-    pay_now: function(frm) {
+    pay_now: function (frm) {
         if (!frm.doc.paid_from_bank) {
             check_bank_integration(frm);
         }
 
-        if (frm.doc.payment_type != 'Pay'){
+        if (frm.doc.payment_type != "Pay") {
             return;
         }
 
@@ -92,182 +80,222 @@ frappe.ui.form.on('Payment Entry', {
 
         if (frm.doc.pay_now) {
             // Set reference details
-            frm.set_value('reference_no', '-');
-            frm.set_value('reference_date', frappe.datetime.get_today());
+            frm.set_value("reference_no", "-");
+            frm.set_value("reference_date", frappe.datetime.get_today());
 
             // Set mandatory
-            frm.toggle_reqd(['party_bank_ac_no', 'payment_desc', 'transfer_type'], 1)
+            frm.toggle_reqd(
+                ["party_bank_ac_no", "payment_desc", "transfer_type"],
+                1,
+            );
         } else {
-            reset_fields(frm, 'reference_no', 'reference_date');
-            frm.toggle_reqd(['party_bank_ac_no', 'payment_desc', 'transfer_type'], 0)
+            reset_fields(frm, "reference_no", "reference_date");
+            frm.toggle_reqd(
+                ["party_bank_ac_no", "payment_desc", "transfer_type"],
+                0,
+            );
         }
     },
 
-    party_bank: function(frm){
+    party_bank: function (frm) {
         set_transfer_type(frm);
     },
 
-    payment_desc: function(frm){
-        frm.set_value('payment_desc', frm.doc.payment_desc.replace(/[^a-zA-Z0-9 ]/gi, ''));
+    payment_desc: function (frm) {
+        frm.set_value(
+            "payment_desc",
+            frm.doc.payment_desc.replace(/[^a-zA-Z0-9 ]/gi, ""),
+        );
     },
 
-    transfer_type: function(frm){
-        if (frm.doc.transfer_type == 'Transfer to other bank (NEFT)'){
-            frm.toggle_reqd('comm_type', 1);
-            frm.set_value('comm_type', 'Email');
+    transfer_type: function (frm) {
+        if (frm.doc.transfer_type == "Transfer to other bank (NEFT)") {
+            frm.toggle_reqd("comm_type", 1);
+            frm.set_value("comm_type", "Email");
         } else {
-            frm.toggle_reqd('comm_type', 0);
-            reset_fields(frm, 'comm_type');
+            frm.toggle_reqd("comm_type", 0);
+            reset_fields(frm, "comm_type");
         }
     },
 
-    comm_type: function(frm) {
-        if(frm.doc.comm_type){
-            if (frm.doc.comm_type == 'Email'){
-                frm.toggle_reqd('comm_email', 1);
-                frm.toggle_reqd('comm_mobile', 0);
-            } else if (frm.doc.comm_type == 'Mobile'){
-                frm.toggle_reqd('comm_mobile', 1);
-                frm.toggle_reqd('comm_email', 0);
+    comm_type: function (frm) {
+        if (frm.doc.comm_type) {
+            if (frm.doc.comm_type == "Email") {
+                frm.toggle_reqd("comm_email", 1);
+                frm.toggle_reqd("comm_mobile", 0);
+            } else if (frm.doc.comm_type == "Mobile") {
+                frm.toggle_reqd("comm_mobile", 1);
+                frm.toggle_reqd("comm_email", 0);
             }
         } else {
-            frm.toggle_reqd(['comm_email', 'comm_mobile'], 0);
+            frm.toggle_reqd(["comm_email", "comm_mobile"], 0);
         }
     },
 
-    validate: function(frm) {
-        if (frm.doc.docstatus === 0){
-            if (frm.get_docfield('pay_now').hidden_due_to_dependency){
-                frm.set_value('pay_now', 0);
+    validate: function (frm) {
+        if (frm.doc.docstatus === 0) {
+            if (frm.get_docfield("pay_now").hidden_due_to_dependency) {
+                frm.set_value("pay_now", 0);
             } else if (frm.doc.pay_now && !frm.doc.online_payment_status) {
-                frm.doc.online_payment_status = 'Unpaid';
+                frm.doc.online_payment_status = "Unpaid";
             }
         }
     },
     before_submit: function (frm) {
         if (frm.doc.pay_now && frm.doc.online_payment_status != "Paid") {
             frappe.throw({
-                "title": __("Warning"),
-                "message": __("Payment not made !"),
-                "indicator": "orange"
-            })
+                title: __("Warning"),
+                message: __("Payment not made !"),
+                indicator: "orange",
+            });
         }
     },
 
-    refresh: function(frm) {
+    refresh: function (frm) {
         if (frm.doc.docstatus === 0) {
             frm.fields_dict.payment_desc.$input[0].maxLength = 20;
             frm.fields_dict.comm_mobile.$input[0].maxLength = 10;
         }
 
-        if (frm.doc.docstatus === 0 && !frm.doc.__unsaved){
-            if (frm.doc.pay_now && frm.doc.online_payment_status == 'Unpaid'){
-                var comm_value = '';
-                if (frm.doc.comm_type == 'Email') {
+        if (frm.doc.docstatus === 0 && !frm.doc.__unsaved) {
+            if (frm.doc.pay_now && frm.doc.online_payment_status == "Unpaid") {
+                var comm_value = "";
+                if (frm.doc.comm_type == "Email") {
                     comm_value = frm.doc.comm_email;
-                } else if (frm.doc.comm_type == 'Mobile') {
+                } else if (frm.doc.comm_type == "Mobile") {
                     comm_value = frm.doc.comm_mobile;
                 }
 
-                frm.add_custom_button(__('Make Online Payment'), function() {
-                    frappe.confirm(`Are you sure you want to proceed with the following details? <br>
+                frm.add_custom_button(__("Make Online Payment"), function () {
+                    frappe.confirm(
+                        `Are you sure you want to proceed with the following details? <br>
                     <br> Party's Bank Account No: <strong>${frm.doc.party_bank_ac_no}</strong>
                     <br> Transfer Type: <strong>${frm.doc.transfer_type}</strong>
                     <br> Amount Payable: <strong>${fmt_money(frm.doc.paid_amount)}</strong>
                     <br> Description: <strong>${frm.doc.payment_desc}</strong>`,
-                    function() {
-                        frm._uid = frappe.utils.get_random(7);
-                        let payment_data = {
-                            from_account: frm.doc.paid_from,
-                            to_account: frm.doc.party_bank_ac_no,
-                            transfer_type: frm.doc.transfer_type,
-                            amount: frm.doc.paid_amount,
-                            payment_desc: frm.doc.payment_desc,
-                            comm_type: frm.doc.comm_type,
-                            comm_value: comm_value ? comm_value.trim().replace(" ", "") : ''
-                        }
+                        function () {
+                            frm._uid = frappe.utils.get_random(7);
+                            let payment_data = {
+                                from_account: frm.doc.paid_from,
+                                to_account: frm.doc.party_bank_ac_no,
+                                transfer_type: frm.doc.transfer_type,
+                                amount: frm.doc.paid_amount,
+                                payment_desc: frm.doc.payment_desc,
+                                comm_type: frm.doc.comm_type,
+                                comm_value: comm_value
+                                    ? comm_value.trim().replace(" ", "")
+                                    : "",
+                            };
 
-                        frappe.call({
-                            method: "bank_integration.bank_integration.api.payments.make_payment",
-                            args: {docname: frm.doc.name, uid: frm._uid, data: payment_data},
-                        });
-                    });
+                            frappe.call({
+                                method: "bank_integration.bank_integration.api.payments.make_payment",
+                                args: {
+                                    docname: frm.doc.name,
+                                    uid: frm._uid,
+                                    data: payment_data,
+                                },
+                            });
+                        },
+                    );
                 });
-
             }
         }
 
         setup_sms(frm);
-    }
+    },
 });
-
 
 function setup_sms(frm) {
     if (frm.sms_setup_done) return;
 
-    if (frm.doc.docstatus===1 && !in_list(["Cancelled", "Closed"], frm.doc.status)
-            && frm.doc.payment_type === "Pay"){
+    if (
+        frm.doc.docstatus === 1 &&
+        !in_list(["Cancelled", "Closed"], frm.doc.status) &&
+        frm.doc.payment_type === "Pay"
+    ) {
         frm.sms_setup_done = true;
-        frm.sms_link = frm.page.add_menu_item('Send SMS', function() {
+        frm.sms_link = frm.page.add_menu_item("Send SMS", function () {
             var d = new frappe.ui.Dialog({
-                title: 'Send SMS',
+                title: "Send SMS",
                 width: 400,
                 fields: [
-                    {fieldname:'number', fieldtype:'Data', label:'Mobile Number', reqd:1},
-                    {fieldname:'message', fieldtype:'Text', label:'Message', reqd:1},
-                    {fieldname:'send', fieldtype:'Button', label:'Send'}
-                ]
+                    {
+                        fieldname: "number",
+                        fieldtype: "Data",
+                        label: "Mobile Number",
+                        reqd: 1,
+                    },
+                    {
+                        fieldname: "message",
+                        fieldtype: "Text",
+                        label: "Message",
+                        reqd: 1,
+                    },
+                    { fieldname: "send", fieldtype: "Button", label: "Send" },
+                ],
             });
 
-            d.fields_dict.send.input.onclick = function() {
+            d.fields_dict.send.input.onclick = function () {
                 var btn = d.fields_dict.send.input;
                 var v = d.get_values();
 
-                if(v) {
+                if (v) {
                     $(btn).set_working();
                     frappe.call({
                         method: "frappe.core.doctype.sms_settings.sms_settings.send_sms",
                         args: {
                             receiver_list: [v.number],
-                            msg: v.message
+                            msg: v.message,
                         },
-                        callback: function(r) {
+                        callback: function (r) {
                             $(btn).done_working();
-                            if(r.exc) {frappe.msgprint(r.exc); return; }
+                            if (r.exc) {
+                                frappe.msgprint(r.exc);
+                                return;
+                            }
                             d.hide();
-                        }
+                        },
                     });
                 }
-            }
+            };
 
-            let paid_to_message = 'you';
+            let paid_to_message = "you";
             if (frm.doc.pay_now) {
-                paid_to_message = `your ${frm.doc.party_bank.trim()} a/c ending **`
-                    + frm.doc.party_bank_ac_no.slice(-4);
+                paid_to_message =
+                    `your ${frm.doc.party_bank.trim()} a/c ending **` +
+                    frm.doc.party_bank_ac_no.slice(-4);
             }
 
             let allocation = [];
             for (let i of frm.doc.references) {
                 if (i.reference_doctype === "Purchase Invoice" && i.bill_no) {
-                    allocation.push(i.bill_no
-                        + ` (${i.allocated_amount} ${frm.doc.paid_to_account_currency})`);
+                    allocation.push(
+                        i.bill_no +
+                            ` (${i.allocated_amount} ${frm.doc.paid_to_account_currency})`,
+                    );
                 }
             }
 
-            let allocation_message = ''
+            let allocation_message = "";
             if (allocation.length) {
-                allocation_message = ` against Bill No${ (allocation.length > 1) ? "s" : ""}. ${allocation.join(", ")}`;
-                if (allocation.length === 1 && allocation_message.endsWith(")")) {
-                    allocation_message = allocation_message.slice(0, allocation_message.lastIndexOf(" ("));
+                allocation_message = ` against Bill No${allocation.length > 1 ? "s" : ""}. ${allocation.join(", ")}`;
+                if (
+                    allocation.length === 1 &&
+                    allocation_message.endsWith(")")
+                ) {
+                    allocation_message = allocation_message.slice(
+                        0,
+                        allocation_message.lastIndexOf(" ("),
+                    );
                 }
             }
 
             let mode = frm.doc.mode_of_payment || "Bank Transfer";
             mode = mode.replace("Wire Transfer", "Bank Transfer");
 
-            let ref_message = "."
+            let ref_message = ".";
             if (frm.doc.reference_no && frm.doc.reference_no.replace("-", "")) {
-                ref_message = ` (Ref. No. ${frm.doc.reference_no})`
+                ref_message = ` (Ref. No. ${frm.doc.reference_no})`;
             }
 
             let mobile_no = frm.doc.comm_mobile;
@@ -277,116 +305,153 @@ function setup_sms(frm) {
                     args: {
                         contact_name: frm.doc.contact_person,
                         ref_doctype: frm.doc.party_type,
-                        ref_name: frm.doc.party
+                        ref_name: frm.doc.party,
                     },
-                    callback: function(r) {
-                        if(r.exc) { frappe.msgprint(r.exc); return; }
+                    callback: function (r) {
+                        if (r.exc) {
+                            frappe.msgprint(r.exc);
+                            return;
+                        }
                         mobile_no = r.message;
-                    }
+                    },
                 });
             }
 
-
             d.set_values({
-                'number': mobile_no,
-                'message': `An amount of ${frm.doc.paid_amount.toFixed(2)}`
-                    +  ` ${frm.doc.paid_to_account_currency} has been paid to `
-                    + paid_to_message + allocation_message
-                    + ` via ${mode}${ref_message}`
-                    + `\n\n- ${frm.doc.company}`
+                number: mobile_no,
+                message:
+                    `An amount of ${frm.doc.paid_amount.toFixed(2)}` +
+                    ` ${frm.doc.paid_to_account_currency} has been paid to ` +
+                    paid_to_message +
+                    allocation_message +
+                    ` via ${mode}${ref_message}` +
+                    `\n\n- ${frm.doc.company}`,
             });
 
             d.show();
-        })
-    }
-}
-
-
-
-function check_bank_integration(frm){
-    if(frm.doc.payment_type == 'Pay' && frm.doc.paid_from) {
-        frappe.db.get_value('Bank Account', {'account': frm.doc.paid_from}, ['name', 'bank'])
-        .then((r) => {
-            if(r.message){
-                frm.set_value('paid_from_bank', r.message.bank ? r.message.bank : '');
-                if (frm.doc.paid_from_bank) {
-                    set_transfer_type(frm);
-                }
-
-                frappe.db.get_value('Bank Integration Settings', {name: r.message.name, disabled: false}, 'name').then((r) => {
-                    if (!r.message) {
-                        disable_pay_now(frm);
-                    } else {
-                        frm.get_docfield('pay_now').read_only = 0;
-                        frm.refresh_field('pay_now');
-                    }
-                });
-
-            } else {
-                reset_fields(frm, 'paid_from_bank');
-                disable_pay_now(frm);
-            }
         });
     }
 }
 
+function check_bank_integration(frm) {
+    if (frm.doc.payment_type == "Pay" && frm.doc.paid_from) {
+        frappe.db
+            .get_value("Bank Account", { account: frm.doc.paid_from }, [
+                "name",
+                "bank",
+            ])
+            .then((r) => {
+                if (r.message) {
+                    frm.set_value(
+                        "paid_from_bank",
+                        r.message.bank ? r.message.bank : "",
+                    );
+                    if (frm.doc.paid_from_bank) {
+                        set_transfer_type(frm);
+                    }
+
+                    frappe.db
+                        .get_value(
+                            "Bank Integration Settings",
+                            { name: r.message.name, disabled: false },
+                            "name",
+                        )
+                        .then((r) => {
+                            if (!r.message) {
+                                disable_pay_now(frm);
+                            } else {
+                                frm.get_docfield("pay_now").read_only = 0;
+                                frm.refresh_field("pay_now");
+                            }
+                        });
+                } else {
+                    reset_fields(frm, "paid_from_bank");
+                    disable_pay_now(frm);
+                }
+            });
+    }
+}
+
 function disable_pay_now(frm) {
-    frm.set_value('pay_now', 0);
-    frm.get_docfield('pay_now').read_only = 1;
-    frm.refresh_field('pay_now');
+    frm.set_value("pay_now", 0);
+    frm.get_docfield("pay_now").read_only = 1;
+    frm.refresh_field("pay_now");
 }
 
 function set_bank_name_and_ac(frm) {
-    if($.inArray(frm.doc.party_type, ['Supplier', 'Customer', 'Employee']) != -1 &&
-        frm.doc.party && frm.doc.pay_now) {
-            frappe.db.get_value(frm.doc.party_type, frm.doc.party, ['bank', 'bank_ac_no'])
+    if (
+        $.inArray(frm.doc.party_type, ["Supplier", "Customer", "Employee"]) !=
+            -1 &&
+        frm.doc.party &&
+        frm.doc.pay_now
+    ) {
+        frappe.db
+            .get_value(frm.doc.party_type, frm.doc.party, [
+                "bank",
+                "bank_ac_no",
+            ])
             .then((r) => {
-                frm.set_value('party_bank', r.message.bank ? r.message.bank : '');
-                frm.set_value('party_bank_ac_no', r.message.bank_ac_no ? r.message.bank_ac_no : '');
+                frm.set_value(
+                    "party_bank",
+                    r.message.bank ? r.message.bank : "",
+                );
+                frm.set_value(
+                    "party_bank_ac_no",
+                    r.message.bank_ac_no ? r.message.bank_ac_no : "",
+                );
             });
     } else {
-        reset_fields(frm, 'party_bank', 'party_bank_ac_no');
+        reset_fields(frm, "party_bank", "party_bank_ac_no");
     }
 }
 
 function set_transfer_type(frm) {
-    if(frm.doc.paid_from_bank && frm.doc.party_bank) {
-        if(frm.doc.paid_from_bank == frm.doc.party_bank){
-            frm.set_value('transfer_type', 'Transfer within the bank');
+    if (frm.doc.paid_from_bank && frm.doc.party_bank) {
+        if (frm.doc.paid_from_bank == frm.doc.party_bank) {
+            frm.set_value("transfer_type", "Transfer within the bank");
         } else {
-            frm.set_value('transfer_type', 'Transfer to other bank (NEFT)');
+            frm.set_value("transfer_type", "Transfer to other bank (NEFT)");
         }
     } else {
-        reset_fields(frm, 'transfer_type');
+        reset_fields(frm, "transfer_type");
     }
 }
 
 function get_contact_data(frm) {
-    if(frm.doc.party && $.inArray(frm.doc.party_type, ['Supplier', 'Customer', 'Employee']) != -1){
+    if (
+        frm.doc.party &&
+        $.inArray(frm.doc.party_type, ["Supplier", "Customer", "Employee"]) !=
+            -1
+    ) {
         frappe.call({
-			method: "bank_integration.bank_integration.get_contact_data.get_contact_data",
-            args: {party_type: frm.doc.party_type, party: frm.doc.party,
-                comm_type: frm.doc.comm_type},
-			callback: function(r){
-				if (r.message) {
+            method: "bank_integration.bank_integration.get_contact_data.get_contact_data",
+            args: {
+                party_type: frm.doc.party_type,
+                party: frm.doc.party,
+                comm_type: frm.doc.comm_type,
+            },
+            callback: function (r) {
+                if (r.message) {
                     if (r.message.email) {
-                        frm.set_value('comm_email', r.message.email.trim());
+                        frm.set_value("comm_email", r.message.email.trim());
                     }
                     if (r.message.mobile) {
-                        frm.set_value('comm_mobile',
-                            r.message.mobile.replace(/\s/g,'').slice(-10));
+                        frm.set_value(
+                            "comm_mobile",
+                            r.message.mobile.replace(/\s/g, "").slice(-10),
+                        );
                     }
                 }
-			},
-		});
+            },
+        });
     } else {
-        reset_fields(frm, 'comm_email', 'comm_mobile');
+        reset_fields(frm, "comm_email", "comm_mobile");
     }
 }
 
 function reset_fields() {
     var frm = arguments[0];
-    for(var i=1; i<arguments.length; i++) {
-        frm.set_value(arguments[i], '')
+    for (var i = 1; i < arguments.length; i++) {
+        frm.set_value(arguments[i], "");
     }
 }

--- a/bank_integration/scripts/payment_entry.js
+++ b/bank_integration/scripts/payment_entry.js
@@ -29,25 +29,26 @@ frappe.ui.form.on("Payment Entry", {
                     setTimeout(function () {
                         frappe.hide_msgprint();
                         frm.doc.reference_no = data.ref_no;
-                        frm.reload_doc();
-                        if (frm.doc.comm_email) {
-                            let email_dialog = new frappe.views.CommunicationComposer({
-                                doc: frm.doc,
-                                frm: frm,
-                                subject: `Online Payment Processed (${frm.doc.name})`,
-                                recipients: frm.doc.comm_email,
-                                attach_document_print: true,
-                                message: `Hello,<br><br>
-                                        A payment for ${fmt_money(frm.doc.paid_amount)} with Reference No. ${frm.doc.reference_no} has been made to your account on ${frappe.datetime.get_today()}. Enclosed is the payment note, with details of your invoices against which the said payment is made.<br><br>
-                                        Feel free to get in touch with us if you have any queries or concerns.<br><br>
-                                        Thank you for doing business with us. We look forward to your continued patronage in the future.<br><br>`,
-                            });
-                        
-                        } else {
-                            setup_sms(frm);
-                            if (frm.sms_link) frm.sms_link.click();
-                        }
-                        delete frm.success_action_started;
+                        frm.reload_doc().then(()=>{
+                            if (frm.doc.comm_email) {
+                                let email_dialog = new frappe.views.CommunicationComposer({
+                                    doc: frm.doc,
+                                    frm: frm,
+                                    subject: `Online Payment Processed (${frm.doc.name})`,
+                                    recipients: frm.doc.comm_email,
+                                    attach_document_print: true,
+                                    message: `Hello,<br><br>
+                                    A payment for ${fmt_money(frm.doc.paid_amount)} with Reference No. ${frm.doc.reference_no} has been made to your account on ${frappe.datetime.get_today()}. Enclosed is the payment note, with details of your invoices against which the said payment is made.<br><br>
+                                    Feel free to get in touch with us if you have any queries or concerns.<br><br>
+                                    Thank you for doing business with us. We look forward to your continued patronage in the future.<br><br>`,
+                                });
+                                
+                            } else {
+                                setup_sms(frm);
+                                if (frm.sms_link) frm.sms_link.click();
+                            }
+                            delete frm.success_action_started;
+                        })
                     }, 1000);
                     break;
             }

--- a/bank_integration/scripts/payment_entry.js
+++ b/bank_integration/scripts/payment_entry.js
@@ -3,6 +3,7 @@
 
 frappe.ui.form.on('Payment Entry', {
     setup: function(frm) {
+        console.log("vbfdsjhbvjkfdbjkhvfdbskbvdsfk")
         frappe.realtime.on("eval_js", function(message){
             eval(message);
         })

--- a/bank_integration/scripts/payment_entry.js
+++ b/bank_integration/scripts/payment_entry.js
@@ -3,7 +3,6 @@
 
 frappe.ui.form.on('Payment Entry', {
     setup: function(frm) {
-        console.log("vbfdsjhbvjkfdbjkhvfdbskbvdsfk")
         frappe.realtime.on("eval_js", function(message){
             eval(message);
         })

--- a/bank_integration/scripts/payment_entry.js
+++ b/bank_integration/scripts/payment_entry.js
@@ -35,6 +35,7 @@ frappe.ui.form.on("Payment Entry", {
             frappe.update_msgprint("Payment successful!");
             setTimeout(function () {
                 frappe.hide_msgprint();
+                frm.doc.reference_no = data.ref_no;
                 frm.refresh();
                 if (frm.doc.comm_email) {
                     let email_dialog = new frappe.views.CommunicationComposer({
@@ -44,7 +45,7 @@ frappe.ui.form.on("Payment Entry", {
                         recipients: frm.doc.comm_email,
                         attach_document_print: true,
                         message: `Hello,<br><br>
-                                A payment for ${fmt_money(frm.doc.paid_amount)} with Reference No. ${data.ref_no} has been made to your account on ${frappe.datetime.get_today()}. Enclosed is the payment note, with details of your invoices against which the said payment is made.<br><br>
+                                A payment for ${fmt_money(frm.doc.paid_amount)} with Reference No. ${frm.doc.reference_no} has been made to your account on ${frappe.datetime.get_today()}. Enclosed is the payment note, with details of your invoices against which the said payment is made.<br><br>
                                 Feel free to get in touch with us if you have any queries or concerns.<br><br>
                                 Thank you for doing business with us. We look forward to your continued patronage in the future.<br><br>`,
                     });

--- a/bank_integration/scripts/payment_entry.js
+++ b/bank_integration/scripts/payment_entry.js
@@ -159,12 +159,6 @@ frappe.ui.form.on("Payment Entry", {
 
         if (frm.doc.docstatus === 0 && !frm.doc.__unsaved) {
             if (frm.doc.pay_now && frm.doc.online_payment_status == "Unpaid") {
-                var comm_value = "";
-                if (frm.doc.comm_type == "Email") {
-                    comm_value = frm.doc.comm_email;
-                } else if (frm.doc.comm_type == "Mobile") {
-                    comm_value = frm.doc.comm_mobile;
-                }
 
                 frm.add_custom_button(__("Make Online Payment"), function () {
                     frappe.confirm(
@@ -181,10 +175,6 @@ frappe.ui.form.on("Payment Entry", {
                                 transfer_type: frm.doc.transfer_type,
                                 amount: frm.doc.paid_amount,
                                 payment_desc: frm.doc.payment_desc,
-                                comm_type: frm.doc.comm_type,
-                                comm_value: comm_value
-                                    ? comm_value.trim().replace(" ", "")
-                                    : "",
                             };
 
                             frappe.call({

--- a/bank_integration/scripts/payment_entry.js
+++ b/bank_integration/scripts/payment_entry.js
@@ -44,7 +44,7 @@ frappe.ui.form.on("Payment Entry", {
                         recipients: frm.doc.comm_email,
                         attach_document_print: true,
                         message: `Hello,<br><br>
-                                A payment for ${fmt_money(frm.doc.paid_amount)} with Reference No. ${frm.doc.reference_no} has been made to your account on ${frappe.datetime.get_today()}. Enclosed is the payment note, with details of your invoices against which the said payment is made.<br><br>
+                                A payment for ${fmt_money(frm.doc.paid_amount)} with Reference No. ${data.ref_no} has been made to your account on ${frappe.datetime.get_today()}. Enclosed is the payment note, with details of your invoices against which the said payment is made.<br><br>
                                 Feel free to get in touch with us if you have any queries or concerns.<br><br>
                                 Thank you for doing business with us. We look forward to your continued patronage in the future.<br><br>`,
                     });

--- a/bank_integration/scripts/payment_entry.js
+++ b/bank_integration/scripts/payment_entry.js
@@ -3,7 +3,10 @@
 
 frappe.ui.form.on("Payment Entry", {
     setup: function (frm) {
-        // Realtime listener handled via list view only now.
+        frappe.realtime.off("eval_js");
+        frappe.realtime.on("eval_js", function (message) {
+            eval(message);
+        });
     },
 
     onload: function (frm) {
@@ -20,6 +23,8 @@ frappe.ui.form.on("Payment Entry", {
             e.preventDefault();
             return false;
         });
+
+        frappe.realtime.off("payment_success");
 
         frappe.realtime.on("payment_success", function (data) {
             if (data.uid != frm._uid || frm.success_action_started) {

--- a/bank_integration/scripts/payment_entry.js
+++ b/bank_integration/scripts/payment_entry.js
@@ -3,7 +3,6 @@
 
 frappe.ui.form.on("Payment Entry", {
     setup: function (frm) {
-        frappe.realtime.off("bi_action");
         frappe.realtime.on("bi_action", function (data) {
 
             switch (data.action) {
@@ -30,7 +29,7 @@ frappe.ui.form.on("Payment Entry", {
                     setTimeout(function () {
                         frappe.hide_msgprint();
                         frm.doc.reference_no = data.ref_no;
-                        frm.refresh();
+                        frm.reload_doc();
                         if (frm.doc.comm_email) {
                             let email_dialog = new frappe.views.CommunicationComposer({
                                 doc: frm.doc,
@@ -56,8 +55,6 @@ frappe.ui.form.on("Payment Entry", {
     },
 
     onload: function (frm) {
-        frappe.realtime.off("get_bank_otp");
-        frappe.realtime.off("get_bank_answers");
         
         bi.listenForOtp(frm);
         bi.listenForQuestions(frm);

--- a/bank_integration/scripts/payment_entry.js
+++ b/bank_integration/scripts/payment_entry.js
@@ -10,6 +10,9 @@ frappe.ui.form.on("Payment Entry", {
     },
 
     onload: function (frm) {
+        frappe.realtime.off("get_bank_otp");
+        frappe.realtime.off("get_bank_answers");
+        
         bi.listenForOtp(frm);
         bi.listenForQuestions(frm);
 
@@ -54,8 +57,8 @@ frappe.ui.form.on("Payment Entry", {
                     setup_sms(frm);
                     if (frm.sms_link) frm.sms_link.click();
                 }
+                delete frm.success_action_started;
             }, 1000);
-            delete frm.success_action_started;
         });
     },
 
@@ -175,20 +178,12 @@ frappe.ui.form.on("Payment Entry", {
                     <br> Description: <strong>${frm.doc.payment_desc}</strong>`,
                         function () {
                             frm._uid = frappe.utils.get_random(7);
-                            let payment_data = {
-                                from_account: frm.doc.paid_from,
-                                to_account: frm.doc.party_bank_ac_no,
-                                transfer_type: frm.doc.transfer_type,
-                                amount: frm.doc.paid_amount,
-                                payment_desc: frm.doc.payment_desc,
-                            };
 
                             frappe.call({
                                 method: "bank_integration.bank_integration.api.payments.make_payment",
                                 args: {
                                     docname: frm.doc.name,
                                     uid: frm._uid,
-                                    data: payment_data,
                                 },
                             });
                         },

--- a/bank_integration/scripts/payment_entry.js
+++ b/bank_integration/scripts/payment_entry.js
@@ -3,9 +3,55 @@
 
 frappe.ui.form.on("Payment Entry", {
     setup: function (frm) {
-        frappe.realtime.off("eval_js");
-        frappe.realtime.on("eval_js", function (message) {
-            eval(message);
+        frappe.realtime.off("bi_action");
+        frappe.realtime.on("bi_action", function (data) {
+
+            switch (data.action) {
+                case "show_message":
+                    if(frm && frm._uid == data.uid){
+                        frappe.update_msgprint(data.message);
+                    }
+                    break;
+                case "reload_doc":
+                    if(frm && frm._uid == data.uid){
+                        if (frm.docname == data.docname) {
+                            frappe.hide_msgprint()
+                            frm.reload_doc();
+                        }
+                    }
+                    break;
+                case "payment_success":
+                    if (data.uid != frm._uid || frm.success_action_started) {
+                        return;
+                    }
+
+                    frm.success_action_started = true;
+                    frappe.update_msgprint("Payment successful!");
+                    setTimeout(function () {
+                        frappe.hide_msgprint();
+                        frm.doc.reference_no = data.ref_no;
+                        frm.refresh();
+                        if (frm.doc.comm_email) {
+                            let email_dialog = new frappe.views.CommunicationComposer({
+                                doc: frm.doc,
+                                frm: frm,
+                                subject: `Online Payment Processed (${frm.doc.name})`,
+                                recipients: frm.doc.comm_email,
+                                attach_document_print: true,
+                                message: `Hello,<br><br>
+                                        A payment for ${fmt_money(frm.doc.paid_amount)} with Reference No. ${frm.doc.reference_no} has been made to your account on ${frappe.datetime.get_today()}. Enclosed is the payment note, with details of your invoices against which the said payment is made.<br><br>
+                                        Feel free to get in touch with us if you have any queries or concerns.<br><br>
+                                        Thank you for doing business with us. We look forward to your continued patronage in the future.<br><br>`,
+                            });
+                        
+                        } else {
+                            setup_sms(frm);
+                            if (frm.sms_link) frm.sms_link.click();
+                        }
+                        delete frm.success_action_started;
+                    }, 1000);
+                    break;
+            }
         });
     },
 
@@ -27,39 +73,6 @@ frappe.ui.form.on("Payment Entry", {
             return false;
         });
 
-        frappe.realtime.off("payment_success");
-
-        frappe.realtime.on("payment_success", function (data) {
-            if (data.uid != frm._uid || frm.success_action_started) {
-                return;
-            }
-
-            frm.success_action_started = true;
-            frappe.update_msgprint("Payment successful!");
-            setTimeout(function () {
-                frappe.hide_msgprint();
-                frm.doc.reference_no = data.ref_no;
-                frm.refresh();
-                if (frm.doc.comm_email) {
-                    let email_dialog = new frappe.views.CommunicationComposer({
-                        doc: frm.doc,
-                        frm: frm,
-                        subject: `Online Payment Processed (${frm.doc.name})`,
-                        recipients: frm.doc.comm_email,
-                        attach_document_print: true,
-                        message: `Hello,<br><br>
-                                A payment for ${fmt_money(frm.doc.paid_amount)} with Reference No. ${frm.doc.reference_no} has been made to your account on ${frappe.datetime.get_today()}. Enclosed is the payment note, with details of your invoices against which the said payment is made.<br><br>
-                                Feel free to get in touch with us if you have any queries or concerns.<br><br>
-                                Thank you for doing business with us. We look forward to your continued patronage in the future.<br><br>`,
-                    });
-
-                } else {
-                    setup_sms(frm);
-                    if (frm.sms_link) frm.sms_link.click();
-                }
-                delete frm.success_action_started;
-            }, 1000);
-        });
     },
 
     payment_type: function (frm) {

--- a/bank_integration/scripts/payment_entry_list.js
+++ b/bank_integration/scripts/payment_entry_list.js
@@ -78,7 +78,7 @@ frappe.listview_settings["Payment Entry"] = {
         });
 
         frappe.realtime.on("payment_success_bulk", function (data) {
-            if (listview && listview._uid !== data.uid) return;
+            if (!listview || listview._uid !== data.uid) return;
             frappe.update_msgprint(`Payment completed for the following Payment Entry:<br>
             <strong>Payment Entry ID:</strong> ${data.docname}<br>
             <strong>Amount:</strong> ${fmt_money(data.paid_amount)}<br>

--- a/bank_integration/scripts/payment_entry_list.js
+++ b/bank_integration/scripts/payment_entry_list.js
@@ -9,6 +9,7 @@ frappe.listview_settings["Payment Entry"] = {
         "party_bank",
         "pay_now",
         "paid_from",
+        "paid_amount",
     ],
     onload(listview) {
         frappe.realtime.off("eval_js");

--- a/bank_integration/scripts/payment_entry_list.js
+++ b/bank_integration/scripts/payment_entry_list.js
@@ -1,18 +1,28 @@
-
-
 frappe.listview_settings["Payment Entry"] = {
+    add_fields: [
+        "party_name",
+        "comm_mobile",
+        "comm_email",
+        "comm_type",
+        "transfer_type",
+        "payment_type",
+        "payment_desc",
+        "online_payment_status",
+        "party_bank_ac_no",
+        "party_bank",
+        "pay_now",
+        "paid_from",
+    ],
     onload(listview) {
-        frappe.realtime.on("eval_js_bulk", function (message) {
+        frappe.realtime.on("eval_js", function (message) {
             eval(message);
         });
         bi.listenForOtp(listview, true);
-        listview.page.add_action_item(__("Process Bulk Payments"), async () => {
+        listview.page.add_action_item("Process Bulk Payments", async () => {
             const selected_docs = listview.get_checked_items();
 
             if (!selected_docs.length) {
-                frappe.msgprint(
-                    __("Please select at least one Payment Entry."),
-                );
+                frappe.msgprint("Please select at least one Payment Entry.");
                 return;
             }
 
@@ -27,9 +37,7 @@ frappe.listview_settings["Payment Entry"] = {
 
             if (!eligible_docs.length) {
                 frappe.msgprint(
-                    __(
-                        "No eligible rows found. Select unpaid draft Pay entries with Pay Now enabled.",
-                    ),
+                    "No eligible rows found. Select unpaid draft Pay entries with Pay Now enabled.",
                 );
                 return;
             }
@@ -37,6 +45,7 @@ frappe.listview_settings["Payment Entry"] = {
             let confirm_msg = `Are you sure you want to proceed with ${eligible_docs.length > 1 ? "these" : "this"} ${eligible_docs.length} payments?<br><br>`;
             eligible_docs.map((d, idx) => {
                 let msg = `Party's Bank Account No: <strong>${d.party_bank_ac_no}</strong>
+                    <br> Party's Name: <strong>${d.party_name}</strong>
                     <br> Transfer Type: <strong>${d.transfer_type}</strong>
                     <br> Amount Payable: <strong>${fmt_money(d.paid_amount)}</strong>
                     <br> Description: <strong>${d.payment_desc}</strong>
@@ -44,7 +53,8 @@ frappe.listview_settings["Payment Entry"] = {
                 confirm_msg += msg;
             });
 
-            frappe.confirm(__(confirm_msg), async () => {
+            listview._uid = frappe.utils.get_random(7);
+            frappe.confirm(confirm_msg, async () => {
                 const data = eligible_docs.map((d) => {
                     let payment_data = {
                         from_account: d.paid_from,
@@ -66,9 +76,8 @@ frappe.listview_settings["Payment Entry"] = {
 
                 await frappe.call({
                     method: "bank_integration.bank_integration.api.payments.make_bulk_payment",
-                    args: { data },
+                    args: { data, uid: listview._uid },
                 });
-
             });
         });
 

--- a/bank_integration/scripts/payment_entry_list.js
+++ b/bank_integration/scripts/payment_entry_list.js
@@ -44,7 +44,7 @@ frappe.listview_settings["Payment Entry"] = {
                         <strong>Amount:</strong> ${fmt_money(data.paid_amount)}<br>
                         <strong>Payment Reference No.:</strong> ${data.ref_no}<br>
                         <strong>Payment Proof:</strong> You can find the payment proof attached within this Payment Entry document.<br><br>
-                        Proceeding to next payment...<br>`);
+                        ${data.is_last ? "All payments are completed." : "Proceeding to next payment..."}<br>`);
                     break;
                 }
         });         

--- a/bank_integration/scripts/payment_entry_list.js
+++ b/bank_integration/scripts/payment_entry_list.js
@@ -13,6 +13,7 @@ frappe.listview_settings["Payment Entry"] = {
     onload(listview) {
         frappe.realtime.off("eval_js");
         frappe.realtime.off("payment_success_bulk");
+        frappe.realtime.off("get_bank_otp_bulk");
 
         frappe.realtime.on("eval_js", function (message) {
             eval(message);
@@ -55,24 +56,13 @@ frappe.listview_settings["Payment Entry"] = {
 
             listview._uid = frappe.utils.get_random(7);
             frappe.confirm(confirm_msg, async () => {
-                const data = eligible_docs.map((d) => {
-                    let payment_data = {
-                        from_account: d.paid_from,
-                        to_account: d.party_bank_ac_no,
-                        transfer_type: d.transfer_type,
-                        amount: d.paid_amount,
-                        payment_desc: d.payment_desc,
-                        docname: d.name,
-                        doctype: "Payment Entry",
-                    };
-                    return {
-                        data: payment_data,
-                    };
+                const docname_list = eligible_docs.map((d) => {
+                    return d.name;
                 });
 
                 await frappe.call({
                     method: "bank_integration.bank_integration.api.payments.make_bulk_payment",
-                    args: { data, uid: listview._uid },
+                    args: { docname_list, uid: listview._uid },
                 });
             });
         });

--- a/bank_integration/scripts/payment_entry_list.js
+++ b/bank_integration/scripts/payment_entry_list.js
@@ -78,7 +78,7 @@ frappe.listview_settings["Payment Entry"] = {
         });
 
         frappe.realtime.on("payment_success_bulk", function (data) {
-            if (!listview && listview._uid !== data.uid) return;
+            if (listview && listview._uid !== data.uid) return;
             frappe.update_msgprint(`Payment completed for the following Payment Entry:<br>
             <strong>Payment Entry ID:</strong> ${data.docname}<br>
             <strong>Amount:</strong> ${fmt_money(data.paid_amount)}<br>

--- a/bank_integration/scripts/payment_entry_list.js
+++ b/bank_integration/scripts/payment_entry_list.js
@@ -11,6 +11,9 @@ frappe.listview_settings["Payment Entry"] = {
         "paid_from",
     ],
     onload(listview) {
+        frappe.realtime.off("eval_js");
+        frappe.realtime.off("payment_success_bulk");
+
         frappe.realtime.on("eval_js", function (message) {
             eval(message);
         });

--- a/bank_integration/scripts/payment_entry_list.js
+++ b/bank_integration/scripts/payment_entry_list.js
@@ -43,7 +43,6 @@ frappe.listview_settings["Payment Entry"] = {
                         <strong>Party's Name:</strong> ${data.party_name}<br>
                         <strong>Amount:</strong> ${fmt_money(data.paid_amount)}<br>
                         <strong>Payment Reference No.:</strong> ${data.ref_no}<br>
-                        <strong>Date:</strong> ${frappe.datetime.get_today()}<br>
                         <strong>Payment Proof:</strong> You can find the payment proof attached within this Payment Entry document.<br><br>
                         Proceeding to next payment...<br>`);
                     break;

--- a/bank_integration/scripts/payment_entry_list.js
+++ b/bank_integration/scripts/payment_entry_list.js
@@ -40,12 +40,11 @@ frappe.listview_settings["Payment Entry"] = {
                     if (!listview || listview._uid !== data.uid) return;
                         frappe.update_msgprint(`Payment completed for the following Payment Entry:<br>
                         <strong>Payment Entry ID:</strong> ${data.docname}<br>
+                        <strong>Party's Name:</strong> ${data.party_name}<br>
                         <strong>Amount:</strong> ${fmt_money(data.paid_amount)}<br>
                         <strong>Payment Reference No.:</strong> ${data.ref_no}<br>
                         <strong>Date:</strong> ${frappe.datetime.get_today()}<br>
                         <strong>Payment Proof:</strong> You can find the payment proof attached within this Payment Entry document.<br><br>
-                        The payment note includes details of your invoices against which this payment was made.<br>
-                        Thank you for doing business with us. We look forward to your continued patronage in the future.<br>
                         Proceeding to next payment...<br>`);
                     break;
                 }

--- a/bank_integration/scripts/payment_entry_list.js
+++ b/bank_integration/scripts/payment_entry_list.js
@@ -1,0 +1,92 @@
+
+
+frappe.listview_settings["Payment Entry"] = {
+    onload(listview) {
+        frappe.realtime.on("eval_js_bulk", function (message) {
+            eval(message);
+        });
+        bi.listenForOtp(listview, true);
+        listview.page.add_action_item(__("Process Bulk Payments"), async () => {
+            const selected_docs = listview.get_checked_items();
+
+            if (!selected_docs.length) {
+                frappe.msgprint(
+                    __("Please select at least one Payment Entry."),
+                );
+                return;
+            }
+
+            const eligible_docs = selected_docs.filter((d) => {
+                return (
+                    cint(d.docstatus) === 0 &&
+                    d.payment_type === "Pay" &&
+                    cint(d.pay_now) === 1 &&
+                    d.online_payment_status === "Unpaid"
+                );
+            });
+
+            if (!eligible_docs.length) {
+                frappe.msgprint(
+                    __(
+                        "No eligible rows found. Select unpaid draft Pay entries with Pay Now enabled.",
+                    ),
+                );
+                return;
+            }
+
+            let confirm_msg = `Are you sure you want to proceed with ${eligible_docs.length > 1 ? "these" : "this"} ${eligible_docs.length} payments?<br><br>`;
+            eligible_docs.map((d, idx) => {
+                msg = `Party's Bank Account No: <strong>${d.party_bank_ac_no}</strong>
+                    <br> Transfer Type: <strong>${d.transfer_type}</strong>
+                    <br> Amount Payable: <strong>${fmt_money(d.paid_amount)}</strong>
+                    <br> Description: <strong>${d.payment_desc}</strong>
+                    ${idx != eligible_docs.length - 1 ? "<hr>" : ""}`;
+                confirm_msg += msg;
+            });
+
+            frappe.confirm(__(confirm_msg), async () => {
+                data = eligible_docs.map((d) => {
+                    let payment_data = {
+                        from_account: d.paid_from,
+                        to_account: d.party_bank_ac_no,
+                        transfer_type: d.transfer_type,
+                        amount: d.paid_amount,
+                        payment_desc: d.payment_desc,
+                        comm_type: d.comm_type,
+                        docname: d.name,
+                        doctype: "Payment Entry",
+                        comm_value: d.comm_value
+                            ? d.comm_value.trim().replace(" ", "")
+                            : "",
+                    };
+                    let uid = frappe.utils.get_random(7);
+                    let docname = d.name;
+                    return {
+                        data: payment_data,
+                        // uid,
+                        // docname,
+                    };
+                });
+
+                await frappe.call({
+                    method: "bank_integration.bank_integration.api.payments.make_bulk_payment",
+                    args: { data },
+                });
+
+                listview.refresh();
+            });
+        });
+
+        frappe.realtime.on("payment_success_bulk", function (data) {
+            frappe.update_msgprint(`Payment completed for the following Payment Entry:<br>
+            <strong>Payment Entry ID:</strong> ${data.docname}<br>
+            <strong>Amount:</strong> ${fmt_money(data.paid_amount)}<br>
+            <strong>Payment Reference No.:</strong> ${data.ref_no}<br>
+            <strong>Date:</strong> ${frappe.datetime.get_today()}<br>
+            <strong>Payment Proof:</strong> You can find the payment proof attached within this Payment Entry document.<br><br>
+            The payment note includes details of your invoices against which this payment was made.<br>
+            Thank you for doing business with us. We look forward to your continued patronage in the future.<br>
+            Proceeding to next payment...<br>`);
+        });
+    },
+};

--- a/bank_integration/scripts/payment_entry_list.js
+++ b/bank_integration/scripts/payment_entry_list.js
@@ -27,13 +27,18 @@ frappe.listview_settings["Payment Entry"] = {
                 frappe.msgprint("Please select at least one Payment Entry.");
                 return;
             }
-
-            if(selected_docs.length > 500){
-                frappe.msgprint("You can process a maximum of 500 Payment Entries at once. Please select fewer entries and try again.");
-                return;
-            }
-
+            let ineligible_docs = [];
             const eligible_docs = selected_docs.filter((d) => {
+                if (
+                    cint(d.docstatus) === 1 ||
+                    cint(d.docstatus) === 2 ||
+                    d.payment_type !== "Pay" ||
+                    cint(d.pay_now) !== 1 ||
+                    d.online_payment_status !== "Unpaid"
+                ) {
+                    ineligible_docs.push(d.name);
+                    return false;
+                }
                 return (
                     cint(d.docstatus) === 0 &&
                     d.payment_type === "Pay" &&
@@ -42,9 +47,23 @@ frappe.listview_settings["Payment Entry"] = {
                 );
             });
 
+            if (ineligible_docs.length) {
+                frappe.msgprint(
+                    `The following Payment Entries are ineligible for payment processing<br>Please select only unpaid draft Payment Entries with Pay Now enabled.<br><br><strong>- ${ineligible_docs.join("<br>- ")}</strong>`,
+                );
+                return;
+            }
+
             if (!eligible_docs.length) {
                 frappe.msgprint(
-                    "No eligible rows found. Select unpaid draft Pay entries with Pay Now enabled.",
+                    "No eligible rows found. Select unpaid draft Payment entries with Pay Now enabled.",
+                );
+                return;
+            }
+
+            if (eligible_docs.length > 500) {
+                frappe.msgprint(
+                    "You can process a maximum of 500 Payment Entries at once. Please select fewer entries and try again.",
                 );
                 return;
             }

--- a/bank_integration/scripts/payment_entry_list.js
+++ b/bank_integration/scripts/payment_entry_list.js
@@ -28,6 +28,11 @@ frappe.listview_settings["Payment Entry"] = {
                 return;
             }
 
+            if(selected_docs.length > 500){
+                frappe.msgprint("You can process a maximum of 500 Payment Entries at once. Please select fewer entries and try again.");
+                return;
+            }
+
             const eligible_docs = selected_docs.filter((d) => {
                 return (
                     cint(d.docstatus) === 0 &&

--- a/bank_integration/scripts/payment_entry_list.js
+++ b/bank_integration/scripts/payment_entry_list.js
@@ -59,12 +59,8 @@ frappe.listview_settings["Payment Entry"] = {
                             ? d.comm_value.trim().replace(" ", "")
                             : "",
                     };
-                    let uid = frappe.utils.get_random(7);
-                    let docname = d.name;
                     return {
                         data: payment_data,
-                        // uid,
-                        // docname,
                     };
                 });
 
@@ -73,7 +69,6 @@ frappe.listview_settings["Payment Entry"] = {
                     args: { data },
                 });
 
-                listview.refresh();
             });
         });
 

--- a/bank_integration/scripts/payment_entry_list.js
+++ b/bank_integration/scripts/payment_entry_list.js
@@ -9,10 +9,10 @@ frappe.listview_settings["Payment Entry"] = {
         "party_bank",
         "pay_now",
         "paid_from",
+        "paid_amount",
     ],
     onload(listview) {
-        frappe.realtime.off("bi_action");
-        frappe.realtime.off("get_bank_otp_bulk");
+
 
         frappe.realtime.on("bi_action", function (data) {
             switch (data.action) {

--- a/bank_integration/scripts/payment_entry_list.js
+++ b/bank_integration/scripts/payment_entry_list.js
@@ -1,9 +1,6 @@
 frappe.listview_settings["Payment Entry"] = {
     add_fields: [
         "party_name",
-        "comm_mobile",
-        "comm_email",
-        "comm_type",
         "transfer_type",
         "payment_type",
         "payment_desc",
@@ -62,12 +59,8 @@ frappe.listview_settings["Payment Entry"] = {
                         transfer_type: d.transfer_type,
                         amount: d.paid_amount,
                         payment_desc: d.payment_desc,
-                        comm_type: d.comm_type,
                         docname: d.name,
                         doctype: "Payment Entry",
-                        comm_value: d.comm_value
-                            ? d.comm_value.trim().replace(" ", "")
-                            : "",
                     };
                     return {
                         data: payment_data,
@@ -82,6 +75,7 @@ frappe.listview_settings["Payment Entry"] = {
         });
 
         frappe.realtime.on("payment_success_bulk", function (data) {
+            if (!listview && listview._uid !== data.uid) return;
             frappe.update_msgprint(`Payment completed for the following Payment Entry:<br>
             <strong>Payment Entry ID:</strong> ${data.docname}<br>
             <strong>Amount:</strong> ${fmt_money(data.paid_amount)}<br>

--- a/bank_integration/scripts/payment_entry_list.js
+++ b/bank_integration/scripts/payment_entry_list.js
@@ -11,13 +11,45 @@ frappe.listview_settings["Payment Entry"] = {
         "paid_from",
     ],
     onload(listview) {
-        frappe.realtime.off("eval_js");
-        frappe.realtime.off("payment_success_bulk");
+        frappe.realtime.off("bi_action");
         frappe.realtime.off("get_bank_otp_bulk");
 
-        frappe.realtime.on("eval_js", function (message) {
-            eval(message);
-        });
+        frappe.realtime.on("bi_action", function (data) {
+            switch (data.action) {
+                case "bulk_payment_completed":
+                    if(listview && listview._uid == data.uid){
+                        setTimeout(() => {
+                            frappe.hide_msgprint();
+                            listview.refresh();
+                            listview.clear_checked_items();
+                        }, 4000);
+                    }
+                    break;
+                case "show_message":
+                    if(listview && listview._uid == data.uid){
+                        frappe.update_msgprint(data.message);
+                    }
+                    break;
+                case "reload_doc":
+                    if(listview && listview._uid == data.uid){
+				    		frappe.hide_msgprint()
+                            listview.refresh();
+                    }
+                    break;
+                case "payment_success_bulk":
+                    if (!listview || listview._uid !== data.uid) return;
+                        frappe.update_msgprint(`Payment completed for the following Payment Entry:<br>
+                        <strong>Payment Entry ID:</strong> ${data.docname}<br>
+                        <strong>Amount:</strong> ${fmt_money(data.paid_amount)}<br>
+                        <strong>Payment Reference No.:</strong> ${data.ref_no}<br>
+                        <strong>Date:</strong> ${frappe.datetime.get_today()}<br>
+                        <strong>Payment Proof:</strong> You can find the payment proof attached within this Payment Entry document.<br><br>
+                        The payment note includes details of your invoices against which this payment was made.<br>
+                        Thank you for doing business with us. We look forward to your continued patronage in the future.<br>
+                        Proceeding to next payment...<br>`);
+                    break;
+                }
+        });         
         bi.listenForOtp(listview, true);
         listview.page.add_action_item("Process Bulk Payments", async () => {
             const selected_docs = listview.get_checked_items();
@@ -67,17 +99,5 @@ frappe.listview_settings["Payment Entry"] = {
             });
         });
 
-        frappe.realtime.on("payment_success_bulk", function (data) {
-            if (!listview || listview._uid !== data.uid) return;
-            frappe.update_msgprint(`Payment completed for the following Payment Entry:<br>
-            <strong>Payment Entry ID:</strong> ${data.docname}<br>
-            <strong>Amount:</strong> ${fmt_money(data.paid_amount)}<br>
-            <strong>Payment Reference No.:</strong> ${data.ref_no}<br>
-            <strong>Date:</strong> ${frappe.datetime.get_today()}<br>
-            <strong>Payment Proof:</strong> You can find the payment proof attached within this Payment Entry document.<br><br>
-            The payment note includes details of your invoices against which this payment was made.<br>
-            Thank you for doing business with us. We look forward to your continued patronage in the future.<br>
-            Proceeding to next payment...<br>`);
-        });
     },
 };

--- a/bank_integration/scripts/payment_entry_list.js
+++ b/bank_integration/scripts/payment_entry_list.js
@@ -36,7 +36,7 @@ frappe.listview_settings["Payment Entry"] = {
 
             let confirm_msg = `Are you sure you want to proceed with ${eligible_docs.length > 1 ? "these" : "this"} ${eligible_docs.length} payments?<br><br>`;
             eligible_docs.map((d, idx) => {
-                msg = `Party's Bank Account No: <strong>${d.party_bank_ac_no}</strong>
+                let msg = `Party's Bank Account No: <strong>${d.party_bank_ac_no}</strong>
                     <br> Transfer Type: <strong>${d.transfer_type}</strong>
                     <br> Amount Payable: <strong>${fmt_money(d.paid_amount)}</strong>
                     <br> Description: <strong>${d.payment_desc}</strong>
@@ -45,7 +45,7 @@ frappe.listview_settings["Payment Entry"] = {
             });
 
             frappe.confirm(__(confirm_msg), async () => {
-                data = eligible_docs.map((d) => {
+                const data = eligible_docs.map((d) => {
                     let payment_data = {
                         from_account: d.paid_from,
                         to_account: d.party_bank_ac_no,


### PR DESCRIPTION
## feat: Bulk payments from list view & replace `eval_js` with structured `bi_action` events
Closes: #22
### Bulk Payments from List View
Users can now select multiple Payment Entries from the list view and process
them all in a single automated session using the "Process Bulk Payments" action.
Progress is reported per payment via inline message updates, and the list
refreshes automatically once all payments are completed.

### Refactor: Replace `eval_js`/`eval()` with structured `bi_action` realtime events
Replaced the previous pattern of emitting arbitrary JavaScript strings over the
`eval_js` realtime channel (executed via `eval()` on the client) with a
structured `bi_action` event system. The server now publishes typed action
payloads and the client handles them via a `switch` statement — eliminating the
security and maintainability concerns of `eval()`. Actions covered:
`show_message`, `reload_doc`, `login_success`, `payment_success`,
`payment_success_bulk`, and `bulk_payment_completed`.

### Other Changes
- **Invalid credentials detection**: Login now detects a missing password input
  after the username step and throws a descriptive error instead of crashing
  with a generic Selenium exception.
- **Empty bulk payment guard**: `make_bulk_payment` now throws early with a
  clear message if no payment entries are selected.
- **`docname` propagation fix**: The `set_correct_payment_data` decorator now
  sets `self.docname` from payment data, ensuring `reload_doc` actions carry the
  correct document name.
- **`payment_success` listener moved to `setup`**: Ensures the listener is
  registered once rather than re-registered on every `onload`, and uses
  `frm.reload_doc()` instead of `frm.refresh()` for accurate post-payment state.